### PR TITLE
support tags in GOPATH mode

### DIFF
--- a/gta_test.go
+++ b/gta_test.go
@@ -323,7 +323,7 @@ func TestGTA_ChangedPackages(t *testing.T) {
 			}
 			defer AllSetenv(t, e.Config.Env)()
 
-			sut, err := New(SetDiffer(difr), SetPackager(newPackager(e.Config, []string{testModule + "/"})))
+			sut, err := New(SetDiffer(difr), SetPackager(newPackager(e.Config, build.Default, []string{testModule + "/"})))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/packager.go
+++ b/packager.go
@@ -53,12 +53,12 @@ type Packager interface {
 }
 
 func NewPackager(prefixes, tags []string) Packager {
-	return newPackager(newLoadConfig(tags), prefixes)
+	build.Default.BuildTags = tags
+	return newPackager(newLoadConfig(tags), build.Default, prefixes)
 }
 
-func newPackager(cfg *packages.Config, prefixes []string) Packager {
+func newPackager(cfg *packages.Config, ctx build.Context, prefixes []string) Packager {
 	importPathsByDir, g, err := dependencyGraph(cfg, prefixes)
-	ctx := build.Default
 	return &packageContext{
 		ctx:               &ctx,
 		err:               err,


### PR DESCRIPTION
Consider tags in GOPATH mode with the older go/build system.