### PR TITLE
workaround issues with vendored packages in module aware mode

### DIFF
--- a/packager.go
+++ b/packager.go
@@ -121,6 +121,7 @@ func (p *packageContext) PackageFromEmptyDir(dir string) (*Package, error) {
 
 // PackageFromImport returns a build package from an import path.
 func (p *packageContext) PackageFromImport(importPath string) (*Package, error) {
+	importPath = stripVendor(importPath)
 	pkg, err := p.ctx.Import(importPath, ".", build.ImportComment)
 	pkg2 := packageFrom(pkg)
 	p.packages[pkg2.ImportPath] = struct{}{}
@@ -288,5 +289,15 @@ func normalizeImportPath(pkg *packages.Package) string {
 	if importPathBase != dirBase {
 		importPath = path.Join(path.Dir(importPath), dirBase)
 	}
+	return importPath
+}
+
+func stripVendor(importPath string) string {
+	segment := "/vendor/"
+	idx := strings.Index(importPath, segment)
+	if idx > -1 {
+		importPath = importPath[idx+len(segment):]
+	}
+
 	return importPath
 }


### PR DESCRIPTION
Work around issues with vendored packages in module aware mode. Since
module aware mode is the default as of Go 1.16 and Go 1.17 is scheduled
to drop support for GOPATH completely, this should be ok to do instead
of trying to be smart and figure out which mode to operate in.

We probably need to refactor the Packager implementation more fully to
completely quit relying on go/build.