### PR TITLE
improve performance of module aware mode

### DIFF
--- a/differ.go
+++ b/differ.go
@@ -17,8 +17,9 @@ import (
 	"sync"
 )
 
-// Differ implements a single method, used to note code diffs
-// and the dirs they occur.
+// A Differ implements provides methods that return values to understand the
+// directories and files that have changed.
+// and the dirs they in which occur.
 type Differ interface {
 	// Diff returns a set of absolute pathed directories that have files that
 	// have been modified.

--- a/gta.go
+++ b/gta.go
@@ -115,6 +115,7 @@ func New(opts ...Option) (*GTA, error) {
 		}
 
 		gta.packager = NewPackager(patterns, gta.tags)
+		// gta.packager = NewPackager(nil, gta.tags)
 	}
 
 	return gta, nil

--- a/gta.go
+++ b/gta.go
@@ -109,7 +109,12 @@ func New(opts ...Option) (*GTA, error) {
 	// packager implementation does not load packages unnecessarily when the
 	// packager is provided as an option.
 	if gta.packager == nil {
-		gta.packager = NewPackager(gta.prefixes, gta.tags)
+		patterns, err := patternsFrom(gta.differ, gta.prefixes)
+		if err != nil {
+			return nil, err
+		}
+
+		gta.packager = NewPackager(patterns, gta.tags)
 	}
 
 	return gta, nil
@@ -388,4 +393,25 @@ func hasPrefixIn(s string, prefixes []string) bool {
 		}
 	}
 	return false
+}
+
+func patternsFrom(differ Differ, prefixes []string) ([]string, error) {
+	dirs, err := differ.Diff()
+	if err != nil {
+		return nil, err
+	}
+	files, err := differ.DiffFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	patterns := make([]string, 0, len(files))
+	for f := range files {
+		if d := dirs[filepath.Dir(f)]; !d.Exists {
+			continue
+		}
+		patterns = append(patterns, "file="+f)
+	}
+
+	return append(patterns, prefixes...), nil
 }

--- a/gtaintegration/gtaintegration_test.go
+++ b/gtaintegration/gtaintegration_test.go
@@ -97,6 +97,8 @@ func TestPackageRemoval(t *testing.T) {
 		gta.SetPrefixes("gtaintegration"),
 	}
 
+	t.Cleanup(chdir(t, filepath.Join("src", "gtaintegration")))
+
 	gt, err := gta.New(options...)
 	if err != nil {
 		t.Fatalf("can't prepare gta: %v", err)
@@ -223,6 +225,8 @@ func TestPackageRemoval_AllGoFilesDeleted(t *testing.T) {
 		gta.SetPrefixes("gtaintegration"),
 	}
 
+	t.Cleanup(chdir(t, filepath.Join("src", "gtaintegration")))
+
 	gt, err := gta.New(options...)
 	if err != nil {
 		t.Fatalf("can't prepare gta: %v", err)
@@ -298,6 +302,8 @@ func TestPackageRemoval_RemoveDirectory(t *testing.T) {
 		gta.SetPrefixes("gtaintegration"),
 	}
 
+	t.Cleanup(chdir(t, filepath.Join("src", "gtaintegration")))
+
 	gt, err := gta.New(options...)
 	if err != nil {
 		t.Fatalf("can't prepare gta: %v", err)
@@ -372,6 +378,8 @@ func TestPackageRemoval_MovePackage(t *testing.T) {
 		gta.SetDiffer(gta.NewGitDiffer()),
 		gta.SetPrefixes("gtaintegration"),
 	}
+
+	t.Cleanup(chdir(t, filepath.Join("src", "gtaintegration")))
 
 	gt, err := gta.New(options...)
 	if err != nil {
@@ -453,6 +461,8 @@ func TestPackageRemoval_MovePackage_NonMasterBranch(t *testing.T) {
 		gta.SetDiffer(gta.NewGitDiffer(gta.SetBaseBranch("origin/feature-branch"))),
 		gta.SetPrefixes("gtaintegration"),
 	}
+
+	t.Cleanup(chdir(t, filepath.Join("src", "gtaintegration")))
 
 	gt, err := gta.New(options...)
 	if err != nil {
@@ -586,9 +596,7 @@ func testMain(m *testing.M) error {
 		return err
 	}
 
-	// This is super jank, but the default packager uses build.Default, so just set GOPATH in it...
-	// TODO(bc): how to deal with this in module aware mode? I suspect we should
-	// use subtests: one with a module and one without.
+	// TODO(bc): don't set GOPATH; it's unsupported as of Go 1.17
 	build.Default.GOPATH = wd
 	os.Setenv("GOPATH", wd)
 
@@ -749,4 +757,17 @@ func mapFromPackages(t *testing.T, pkg *gta.Packages) map[string]interface{} {
 	}
 
 	return m
+}
+
+func chdir(t *testing.T, dir string) func() {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Chdir(dir)
+	return func() {
+		os.Chdir(wd)
+	}
 }

--- a/gtaintegration/testdata/gtaintegration/src/gtaintegration/go.mod
+++ b/gtaintegration/testdata/gtaintegration/src/gtaintegration/go.mod
@@ -1,0 +1,3 @@
+module gtaintegration
+
+go 1.16

--- a/packager.go
+++ b/packager.go
@@ -222,6 +222,10 @@ func dependencyGraph(cfg *packages.Config, patterns []string) (moduleNamesByDir 
 		patterns[i] = fmt.Sprintf("%s...", pat)
 	}
 
+	if len(patterns) == 0 {
+		patterns = []string{"..."}
+	}
+
 	loadedPackages, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("loading packages: %w", err)

--- a/packager.go
+++ b/packager.go
@@ -116,10 +116,10 @@ func (p *packageContext) PackageFromDir(dir string) (*Package, error) {
 
 // PackageFromEmptyDir returns a build package from a directory.
 func (p *packageContext) PackageFromEmptyDir(dir string) (*Package, error) {
-	// TODO(bc): construct the Package from the information about the module or GOPATH
 	pkg, err := p.ctx.ImportDir(dir, build.FindOnly)
 	pkg2 := packageFrom(pkg)
 	resolveLocal(pkg2, dir, p.modulesNamesByDir)
+	pkg2.ImportPath = stripVendor(pkg2.ImportPath)
 	p.packages[pkg2.ImportPath] = struct{}{}
 	return pkg2, err
 }

--- a/scripts/detect-regression.sh
+++ b/scripts/detect-regression.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+########################################################################
+# Description: Detect regressions by comparing two gta binaries; an old
+#              version and a new version. To use this script, compile
+#              the old version of gta and the new version of gta.
+#
+#              This script will compare the results and timing of the
+#              two gta binaries against the last 100 merges in the repo
+#              in the current directory.
+########################################################################
+if [[ -z "$1" || -z "$2" ]]; then
+  printf "usage: ${BASH_SOURCE[0]} OLD_GTA NEW_GTA\n" >&2
+  exit 1
+fi
+
+set -u -o pipefail
+
+gta_old_bin="$1"
+gta_new_bin="$2"
+count=100
+
+if [[ "$(uname)" == "Darwin" ]];
+then
+  time=gtime
+fi
+
+branch=$(git branch --show-current)
+
+function restore_branch() {
+  git checkout "${branch}"
+}
+
+trap restore_branch EXIT
+
+for commit in $(git log --first-parent --merges --pretty=format:"%H" | head -n "$count")
+do
+    printf "Merge commit: $commit" >&2
+    results_dir="results/$commit"
+    mkdir -p "$results_dir"
+
+    git checkout "$commit^2" >/dev/null 2>&1
+
+    changed_files="$results_dir/changed.txt"
+    git diff --name-only --no-renames -r "$commit"^1..."$commit" | sed "s|^|$(git rev-parse --show-toplevel)/|" >"$changed_files"
+    files_changed=$(wc -l "$changed_files" | tr -s ' ' | cut -d ' ' -f 2)
+    printf " [# files changed: $files_changed]" >&2
+
+    gta_old_result="$results_dir/gta.txt"
+    export GO111MODULE=off
+    gta_old_time=$(/usr/bin/env "$time" -f '%es' "$gta_old_bin" -changed-files "$changed_files" -include do/doge/,do/exp/,do/services/,do/teams/,do/tools/ -tags integration 2>&1 >"$gta_old_result")
+    gta_new_result="$results_dir/gta2.txt"
+    export GO111MODULE=on
+    gta_new_time=$(/usr/bin/env "$time" -f '%es' "$gta_new_bin" -changed-files "$changed_files" -include do/doge/,do/exp/,do/services/,do/teams/,do/tools/ -tags integration 2>&1 >"$gta_new_result")
+    printf " [old: ${gta_old_time}]" >&2
+    printf " [new: ${gta_new_time}]\n" >&2
+    diff "$gta_old_result" "$gta_new_result" | sed "s/^/  /"
+done


### PR DESCRIPTION
#### summary

This PR is to improve the performance of gta on large repositories in module aware mode. On a large monorepo performance isn't quite as good as it was in GOPATH mode in older versions of gta, but I believe it's acceptable and it's orders of magnitude better than it was in module aware mode prior to these changes; the differences are measured in seconds on a large monorepo instead of minutes or hours.

I compared the results of this version of gta with the previous version of gta against the last 1000 merge commits in cthulhu to make sure there aren't any differences in output.

##### add script to test for regressions


##### store the forward dependency graph from packages.Load


##### use the forward graph stored in packageContext

Use the forward graph stored in packageContext to satisfy ImportPackage
instead of relying on go/build's Import functions.


##### strip the vendor directory in PackageFromEmptyDir

Strip the vendor directory in module aware mode in PackageFromEmptyDir
so that dependencies in module aware mode are calculated correctly.


##### load packages based on changed files

Load packages based on changed files, so that all the expected packages
will be in the forward graph. This is important when files for another
OS are changed and those files import packages that are not otherwise
imported by the files for the current build environment.

For example, given
* vcs.test/bar/foo_linux.go is changed
* vcs.test/bar/foo_linux.go imports vcs.test/quux
* no files in vcs.test/bar used to compile for Darwin import
  vcs.test/quux
* gta is run on darwin
* GOOS is not set

Then when gta tries to get the package for vcs.test/quux, it won't
exist, because "golang.org/x/tools/go/packages.Package".Load will not
have added any information about it.

Another alternative is to use "..." for the prefixes when calling
Package.Load, but that takes a bit longer.


##### load all packages when no pattern is given


##### fix integration tests to work in module aware mode


