### PR TITLE
don't panic when a package has not been loaded

### DIFF
--- a/gta.go
+++ b/gta.go
@@ -155,9 +155,7 @@ func (g *GTA) ChangedPackages() (*Packages, error) {
 	packageFromImport := func(path string) (*Package, error) {
 		pkg, err := g.packager.PackageFromImport(path)
 		if err != nil {
-			if _, ok := err.(*build.NoGoError); !ok {
-				return nil, fmt.Errorf("building packages for %q: %v", path, err)
-			}
+			return nil, err
 		}
 
 		return pkg, nil

--- a/packager.go
+++ b/packager.go
@@ -213,15 +213,22 @@ func resolveLocal(pkg *Package, dir string, modulesByDir map[string]string) {
 // graphs. When in GOPATH mode the map of directories to import paths will be
 // empty.
 func dependencyGraph(cfg *packages.Config, patterns []string) (moduleNamesByDir map[string]string, forward map[string]map[string]struct{}, reverse map[string]map[string]struct{}, err error) {
+	loadAllPackages := true
 	for i, pat := range patterns {
-		if strings.HasPrefix(pat, "file=") || strings.HasSuffix(pat, "...") {
+		if strings.HasPrefix(pat, "file=") {
+			continue
+		}
+
+		// prefixes were provided, so don't load all packages
+		loadAllPackages = false
+		if strings.HasSuffix(pat, "...") {
 			continue
 		}
 
 		patterns[i] = fmt.Sprintf("%s...", pat)
 	}
 
-	if len(patterns) == 0 {
+	if loadAllPackages {
 		patterns = []string{"..."}
 	}
 

--- a/packager.go
+++ b/packager.go
@@ -128,8 +128,7 @@ func (p *packageContext) PackageFromEmptyDir(dir string) (*Package, error) {
 func (p *packageContext) PackageFromImport(importPath string) (*Package, error) {
 	importPath = stripVendor(importPath)
 	if _, ok := p.forward[importPath]; !ok {
-		// TODO(bc): importPath is probably _not_ the right thing to use for Dir. So what _is_?
-		return nil, &build.NoGoError{Dir: importPath}
+		return nil, fmt.Errorf("%s not found", importPath)
 	}
 
 	pkg := &Package{


### PR DESCRIPTION
##### handle excluded imports correctly

Return an error in GTA.ChangedPackages() when the import path is not
found by Packer.PackageFromImport.

This resolves a panic when a changed package is not within the provided
prefixes _and_ is not imported by any of the packages within the
provided prefixes.


##### load all packages when no prefixes are provided


