### PR TITLE
fix deleted package handling

### DIFF
--- a/gta.go
+++ b/gta.go
@@ -347,7 +347,7 @@ func (g *GTA) findImportPath(abs string) (string, error) {
 		return path.Join(importPath, base), err
 	}
 
-	return path.Join(pkg.ImportPath, base), nil
+	return pkg.ImportPath, nil
 }
 
 type byPackageImportPath []Package


### PR DESCRIPTION
Fix findImportPath to return the correct package name when a parent
directory of a deleted package has go files.