### PR TITLE
update to work with Go 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.14','1.15']
+        go: ['1.16','1.17']
     steps:
     - name: setup Go
       uses: actions/setup-go@v2

--- a/gtaintegration/gtaintegration_test.go
+++ b/gtaintegration/gtaintegration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package gtaintegration


### PR DESCRIPTION
Update tests to test with Go 1.17 and 1.16, the two most recent releases
of Go.

Update build constraints to use the new form introduced in Go 1.17.