### PR TITLE
Smarter test handling

### DIFF
--- a/gta_test.go
+++ b/gta_test.go
@@ -803,3 +803,54 @@ func TestJSONRoundtrip(t *testing.T) {
 		t.Errorf("(-want, +got)\n%s", diff)
 	}
 }
+
+func TestIsIgnoredByGo(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected bool
+	}{
+		{
+			in:       "/",
+			expected: false,
+		}, {
+			in:       "/foo",
+			expected: false,
+		}, {
+			in:       "/foo/bar",
+			expected: false,
+		}, {
+			in:       "foo",
+			expected: false,
+		}, {
+			in:       "testdata",
+			expected: true,
+		}, {
+			in:       "/testdata",
+			expected: true,
+		}, {
+			in:       "/foo/testdata",
+			expected: true,
+		}, {
+			in:       "foo/testdata/bar",
+			expected: true,
+		}, {
+			in:       "/foo/_bar",
+			expected: true,
+		}, {
+			in:       "/foo/.bar",
+			expected: true,
+		}, {
+			in:       "foo/_bar/quux",
+			expected: true,
+		}, {
+			in:       "/foo/.bar/quux",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		got := isIgnoredByGo(tt.in)
+		if want := tt.expected; got != want {
+			t.Errorf("isIgnoredByGoBuild(%q) = %v; want %v", tt.in, got, want)
+		}
+	}
+}

--- a/gtaintegration/gtaintegration_test.go
+++ b/gtaintegration/gtaintegration_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/digitalocean/gta"
@@ -24,7 +25,7 @@ import (
 )
 
 const (
-	repoRoot = "testdata/gtaintegration"
+	repoRoot = "gtaintegration"
 )
 
 func TestMain(m *testing.M) {
@@ -675,11 +676,11 @@ func prepareTemp() string {
 			return err
 		}
 
+		dstPath := filepath.Join(d, strings.TrimPrefix(path, "testdata/"))
 		if info.IsDir() {
-			dir := filepath.Join(d, path)
-			err := os.Mkdir(dir, info.Mode())
+			err := os.Mkdir(dstPath, info.Mode())
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("could not create directory (%s)", dir))
+				return errors.Wrap(err, fmt.Sprintf("could not create directory (%s)", dstPath))
 			}
 			return nil
 		}
@@ -690,9 +691,9 @@ func prepareTemp() string {
 		}
 		defer src.Close()
 
-		dst, err := os.Create(filepath.Join(d, path))
+		dst, err := os.Create(dstPath)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("could not open file (%s)", path))
+			return errors.Wrap(err, fmt.Sprintf("could not create file (%s)", dstPath))
 		}
 		defer dst.Close()
 


### PR DESCRIPTION
##### handle directories arbitrarily deep under an ignored directory


##### gtaintegration: trim testdata prefix

Trim testdata prefix when copying files to temp directory.


##### do not report dependents when only testdata is changed


##### ignore dependents when only test files are changed


