### PR TITLE
gtaintegration: ensure master branch exists

### DIFF
--- a/gtaintegration/gtaintegration_test.go
+++ b/gtaintegration/gtaintegration_test.go
@@ -615,7 +615,7 @@ func createRepo(path string) error {
 
 	ctx := context.Background()
 	// git init
-	if _, err := runGit(ctx, path, "init"); err != nil {
+	if _, err := runGit(ctx, path, "init", "-b", "master"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If git is configured to use a default branch other than `master` then
the integration tests all fail because they assume master was created
during repo initialization.