### PR TITLE
support github actions

### DIFF
--- a/gta_test.go
+++ b/gta_test.go
@@ -947,7 +947,7 @@ func TestIsIgnoredByGo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got := isIgnoredByGo(tt.in)
+		got := isIgnoredByGo(tt.in, []string{"/"})
 		if want := tt.expected; got != want {
 			t.Errorf("isIgnoredByGoBuild(%q) = %v; want %v", tt.in, got, want)
 		}
@@ -1002,7 +1002,7 @@ func TestDeepestUnignoredDir(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got := deepestUnignoredDir(tt.in)
+		got := deepestUnignoredDir(tt.in, []string{"/"})
 		if want := tt.expected; got != want {
 			t.Errorf("deepestUnignoredDir(%q) = %v; want %v", tt.in, got, want)
 		}

--- a/gta_test.go
+++ b/gta_test.go
@@ -944,10 +944,13 @@ func TestIsIgnoredByGo(t *testing.T) {
 		}, {
 			in:       "/foo/.bar/quux",
 			expected: true,
+		}, {
+			in:       "/foo/_bar/baz",
+			expected: false,
 		},
 	}
 	for _, tt := range tests {
-		got := isIgnoredByGo(tt.in, []string{"/"})
+		got := isIgnoredByGo(tt.in, []string{"/", "/foo/_bar/baz"})
 		if want := tt.expected; got != want {
 			t.Errorf("isIgnoredByGoBuild(%q) = %v; want %v", tt.in, got, want)
 		}


### PR DESCRIPTION
##### support github actions

Do not look for ignored directories above paths that Go uses for
determining whether to build. This supports GitHub Actions, which places
the mounted working directories in a directory that starts with two
underscores when using a container.


##### add test to verify isIgnoredByGo behavior


