### PR TITLE
Tighten the scope of changes considered

### DIFF
--- a/gta_test.go
+++ b/gta_test.go
@@ -651,6 +651,25 @@ func TestGTA_ChangedPackages(t *testing.T) {
 
 		testChangedPackages(t, diff, nil, want)
 	})
+
+	t.Run("change non-go file", func(t *testing.T) {
+		diff := map[string]Directory{
+			"embed":      {Exists: true, Files: []string{"README.md"}},
+			"unimported": {Exists: true, Files: []string{"unimported.go"}},
+		}
+
+		want := &Packages{
+			Dependencies: map[string][]Package{},
+			Changes: []Package{
+				{ImportPath: "unimported", Dir: "unimported"},
+			},
+			AllChanges: []Package{
+				{ImportPath: "unimported", Dir: "unimported"},
+			},
+		}
+
+		testChangedPackages(t, diff, nil, want)
+	})
 }
 
 func TestGTA_Prefix(t *testing.T) {


### PR DESCRIPTION
Now that gta considers embedded files and Go properly supports file embedding, use that information when deciding whether a package is changed instead of considering any changed file in a package's directory to be a change to the package itself.