### PR TITLE
Create tag workflow to facilitate semver

### DIFF
--- a/.github/workflows/git.yaml
+++ b/.github/workflows/git.yaml
@@ -6,6 +6,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2.0.0
+    - uses: actions/checkout@v4
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -1,0 +1,26 @@
+name: update tags
+on:
+  push:
+    tags: ['v*.*.*']
+    branches-ignore: ['**']
+jobs:
+  update-reftags:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run shell command
+        shell: bash
+        run: |
+          # Parse the MAJOR/MINOR version from the input tag.
+          MINOR="${GITHUB_REF_NAME%.*}"                # v1.2
+          MAJOR="${MINOR%.*}"                          # v1
+
+          # Update tags.
+          git tag -f "${MAJOR}"
+          git tag -f "${MINOR}"
+
+          # Push
+          git push --force origin --tags

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run shell command
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: test
       run: $GITHUB_WORKSPACE/scripts/ci.sh


### PR DESCRIPTION
Create tag workflow to facilitate semver

E.g. if we create a `v1.2.3` release, automatically create/update the `v1.2` and `v1` tags.