### PR TITLE
[FEATURE] `-h2h` flag implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ On macOS, this may be a measly 256. Consider raising that maximum to something r
 sudo ulimit -n 4096
 ```
 
+## Tool Arguments
+| Argument          | Description                                                                                                                                                                                                                      | Example                                                                     |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| `-base`           | sets the base branch for the process. default: `origin/master`                                                                                                                                                                   | `gta -base origin/my-branch`                                                |
+| `-include`        | A comma separated list of packages to include.                                                                                                                                                                                   | `gta -include "github.com/myorg/myproject/pkg,github.com/myorg/myproject2"` |
+| `-merge`          | A boolean flag to compare against the last merged commit from the base. It cannot be used together with `-h2h` and `-changed-files`.                                                                                             | `gta -merge`                                                                |
+| `-json`           | A boolean flag that changes output format to json.                                                                                                                                                                               | `gta -json`                                                                 |
+| `-buildable-only` | A boolean flag to look up only the buildable packages between the changes. Those with an at least one `.go` file inside. It cannot be used together with `-json`.                                                                | `gta -buildable-only`                                                       |
+| `-changed-files`  | A boolean flag to provide a custom file list of line-breaked paths to check the dependent ones of those instead of using git to detect the changes. Paths must be absolute. It cannot be used together with `-merge` and `-h2h`. | `gta -changed-files changed_files.txt`                                      |
+| `-tags`           | A comma separated list of `// +build` tags to consider.                                                                                                                                                                          | `gta -tags "linux,debug,test"`                                              |
+| `-h2h`            | A boolean flag to compare base and current branch `HEAD` to `HEAD` instead of comparing against the root commit shared with the base branch. It cannot be used together with `-merge` and `changed-files`                        | `gta -h2h`                                                                  |
+
 ## License
 
 This application is distributed under the Apache 2 license found in [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -46,18 +46,6 @@ On macOS, this may be a measly 256. Consider raising that maximum to something r
 sudo ulimit -n 4096
 ```
 
-## Tool Arguments
-| Argument          | Description                                                                                                                                                                                                                      | Example                                                                     |
-|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| `-base`           | sets the base branch for the process. default: `origin/master`                                                                                                                                                                   | `gta -base origin/my-branch`                                                |
-| `-include`        | A comma separated list of packages to include.                                                                                                                                                                                   | `gta -include "github.com/myorg/myproject/pkg,github.com/myorg/myproject2"` |
-| `-merge`          | A boolean flag to compare against the last merged commit from the base. It cannot be used together with `-h2h` and `-changed-files`.                                                                                             | `gta -merge`                                                                |
-| `-json`           | A boolean flag that changes output format to json.                                                                                                                                                                               | `gta -json`                                                                 |
-| `-buildable-only` | A boolean flag to look up only the buildable packages between the changes. Those with an at least one `.go` file inside. It cannot be used together with `-json`.                                                                | `gta -buildable-only`                                                       |
-| `-changed-files`  | A boolean flag to provide a custom file list of line-breaked paths to check the dependent ones of those instead of using git to detect the changes. Paths must be absolute. It cannot be used together with `-merge` and `-h2h`. | `gta -changed-files changed_files.txt`                                      |
-| `-tags`           | A comma separated list of `// +build` tags to consider.                                                                                                                                                                          | `gta -tags "linux,debug,test"`                                              |
-| `-h2h`            | A boolean flag to compare base and current branch `HEAD` to `HEAD` instead of comparing against the root commit shared with the base branch. It cannot be used together with `-merge` and `changed-files`                        | `gta -h2h`                                                                  |
-
 ## License
 
 This application is distributed under the Apache 2 license found in [LICENSE](LICENSE)

--- a/cmd/gta/main.go
+++ b/cmd/gta/main.go
@@ -22,7 +22,6 @@ import (
 	"syscall"
 
 	"github.com/digitalocean/gta"
-
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -35,6 +34,7 @@ func main() {
 	flagBuildableOnly := flag.Bool("buildable-only", true, "keep buildable changed packages only")
 	flagChangedFiles := flag.String("changed-files", "", "path to a file containing a newline separated list of files that have changed")
 	flagTags := flag.String("tags", "", "a list of build tags to consider")
+	flagHeadToHead := flag.Bool("h2h", false, "diff using the HEAD of the base branch and the HEAD of the current branch")
 
 	flag.Parse()
 
@@ -44,6 +44,14 @@ func main() {
 
 	if *flagMerge && len(*flagChangedFiles) > 0 {
 		log.Fatal("changed files must not be provided when using the latest merge commit")
+	}
+
+	if *flagMerge && *flagHeadToHead {
+		log.Fatal("-merge and -h2h cannot be used together")
+	}
+
+	if *flagHeadToHead && len(*flagChangedFiles) > 0 {
+		log.Fatal("-changed-files and -h2h cannot be used together")
 	}
 
 	var tags []string
@@ -61,6 +69,7 @@ func main() {
 		gitDifferOptions := []gta.GitDifferOption{
 			gta.SetBaseBranch(*flagBase),
 			gta.SetUseMergeCommit(*flagMerge),
+			gta.SetUseHeadToHead(*flagHeadToHead),
 		}
 		options = append(options, gta.SetDiffer(gta.NewGitDiffer(gitDifferOptions...)))
 	} else {

--- a/cmd/gta/main.go
+++ b/cmd/gta/main.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 
 	"github.com/digitalocean/gta"
+
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -34,7 +35,6 @@ func main() {
 	flagBuildableOnly := flag.Bool("buildable-only", true, "keep buildable changed packages only")
 	flagChangedFiles := flag.String("changed-files", "", "path to a file containing a newline separated list of files that have changed")
 	flagTags := flag.String("tags", "", "a list of build tags to consider")
-	flagHeadToHead := flag.Bool("h2h", false, "diff using the HEAD of the base branch and the HEAD of the current branch")
 
 	flag.Parse()
 
@@ -44,14 +44,6 @@ func main() {
 
 	if *flagMerge && len(*flagChangedFiles) > 0 {
 		log.Fatal("changed files must not be provided when using the latest merge commit")
-	}
-
-	if *flagMerge && *flagHeadToHead {
-		log.Fatal("-merge and -h2h cannot be used together")
-	}
-
-	if *flagHeadToHead && len(*flagChangedFiles) > 0 {
-		log.Fatal("-changed-files and -h2h cannot be used together")
 	}
 
 	var tags []string
@@ -69,7 +61,6 @@ func main() {
 		gitDifferOptions := []gta.GitDifferOption{
 			gta.SetBaseBranch(*flagBase),
 			gta.SetUseMergeCommit(*flagMerge),
-			gta.SetUseHeadToHead(*flagHeadToHead),
 		}
 		options = append(options, gta.SetDiffer(gta.NewGitDiffer(gitDifferOptions...)))
 	} else {

--- a/differ.go
+++ b/differ.go
@@ -47,17 +47,11 @@ func SetBaseBranch(baseBranch string) GitDifferOption {
 	}
 }
 
-// SetUseHeadToHead sets the useHeadToHead field on a git differ
-func SetUseHeadToHead(useHeadToHead bool) GitDifferOption {
-	return func(gd *git) {
-		gd.useHeadToHead = useHeadToHead
-	}
-}
-
 // NewGitDiffer returns a Differ that determines differences using git.
 func NewGitDiffer(opts ...GitDifferOption) Differ {
 	g := &git{
-		baseBranch: "origin/master",
+		useMergeCommit: false,
+		baseBranch:     "origin/master",
 	}
 
 	for _, opt := range opts {
@@ -91,7 +85,6 @@ type differ struct {
 type git struct {
 	baseBranch     string
 	useMergeCommit bool
-	useHeadToHead  bool
 	onceDiff       sync.Once
 	changedFiles   map[string]struct{}
 	diffErr        error
@@ -174,14 +167,32 @@ func (g *git) diff() (map[string]struct{}, error) {
 	g.onceDiff.Do(func() {
 		files, err := func() (map[string]struct{}, error) {
 			// We get the root of the repository to build our full path.
-			root, err := g.root()
+			out, err := execWithStderr(exec.Command("git", "rev-parse", "--show-toplevel"))
+			if err != nil {
+				return nil, err
+			}
+			root := strings.TrimSpace(string(out))
+			// get the revision from which HEAD was branched from g.baseBranch.
+			parent1, err := g.branchPointOf("HEAD")
 			if err != nil {
 				return nil, err
 			}
 
-			parent1, rightwardParents, err := g.getParents()
-			if err != nil {
-				return nil, fmt.Errorf("git differ failed to get branch parents when getting go.mod dependency changes: %w", err)
+			// If the branch point is unknown, fall back to using the base branch. In
+			// most cases, this will be fine, but results in a corner case when base
+			// branch has been merged into the branch since branch was created. In
+			// that case, the differences from the base branch and the most recent
+			// merge will not be considered.
+			if parent1 == "" {
+				parent1 = g.baseBranch
+			}
+
+			rightwardParents := []string{"HEAD"}
+			if g.useMergeCommit {
+				parent1, rightwardParents, err = g.getMergeParents()
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			files := make(map[string]struct{})
@@ -223,52 +234,6 @@ func (g *git) diff() (map[string]struct{}, error) {
 	})
 
 	return g.changedFiles, g.diffErr
-}
-
-func (g *git) getParents() (parent1 string, rightwardParents []string, errR error) {
-	parent1 = g.baseBranch
-	rightwardParents = []string{"HEAD"}
-
-	// When HeadToHead is not set, vanilla behavior. Get root commit when the branch was created from the base as the parent.
-	if !g.useHeadToHead {
-		// get the revision from which HEAD was branched from g.baseBranch.
-		resParent1, err := g.branchPointOf("HEAD")
-		if err != nil {
-			errR = err
-
-			return
-		}
-
-		// If the branch point is unknown, fall back to using the base branch. In
-		// most cases, this will be fine, but results in a corner case when base
-		// branch has been merged into the branch since branch was created. In
-		// that case, the differences from the base branch and the most recent
-		// merge will not be considered.
-		if resParent1 != "" {
-			parent1 = resParent1
-		}
-	}
-
-	if g.useMergeCommit {
-		resParent1, resRightwardParents, err := g.getMergeParents()
-		if err != nil {
-			errR = err
-			return
-		}
-
-		parent1, rightwardParents = resParent1, resRightwardParents
-	}
-
-	return
-}
-
-func (g *git) root() (string, error) {
-	out, err := execWithStderr(exec.Command("git", "rev-parse", "--show-toplevel"))
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(string(out)), nil
 }
 
 // diffPaths returns the path that have changed.


### PR DESCRIPTION
Adding a -h2h flag option for the tool so it compares changes between base branch and the current branch `HEAD` to `HEAD` instead of looking for the shared root commit.

This is different behavior than `-merge` flag, since `-merge` compares last merged commit and parent or in case there's not, the `HEAD`

This might be useful for those who merge/update their base branch to their development branch in the development pipeline