### PR TITLE
Support unvendored repositories: precise go.mod/go.sum dependency diffing (rebased on #73)

### DIFF
--- a/cmd/gta/main.go
+++ b/cmd/gta/main.go
@@ -35,6 +35,7 @@ func main() {
 	flagChangedFiles := flag.String("changed-files", "", "path to a file containing a newline separated list of files that have changed")
 	flagTags := flag.String("tags", "", "a list of build tags to consider")
 	flagTestTransitive := flag.Bool("test-transitive", true, "legacy behavior; include transitive test dependencies in the reverse dependency graph traversal")
+	flagNoWorkspace := flag.Bool("no-workspace", false, "disable Go workspace (go.work) support; operate in single-module mode")
 
 	flag.Parse()
 
@@ -55,6 +56,7 @@ func main() {
 		gta.SetPrefixes(parseStringSlice(*flagInclude)...),
 		gta.SetTags(tags...),
 		gta.SetIncludeTransitiveTestDeps(*flagTestTransitive),
+		gta.SetDisableWorkspace(*flagNoWorkspace),
 	}
 
 	if len(*flagChangedFiles) == 0 {

--- a/differ.go
+++ b/differ.go
@@ -30,6 +30,11 @@ type Differ interface {
 	DiffFiles() (map[string]bool, error)
 }
 
+// BaseFileReader provides access to file content at the base branch/commit.
+type BaseFileReader interface {
+	ReadBaseFile(relativePath string) ([]byte, error)
+}
+
 // GitDifferOption is an option function used to modify a git differ
 type GitDifferOption func(*git)
 
@@ -59,7 +64,8 @@ func NewGitDiffer(opts ...GitDifferOption) Differ {
 	}
 
 	return &differ{
-		diff: g.diff,
+		diff:         g.diff,
+		readBaseFile: g.readBaseFile,
 	}
 }
 
@@ -78,7 +84,17 @@ func NewFileDiffer(files []string) Differ {
 }
 
 type differ struct {
-	diff func() (map[string]struct{}, error)
+	diff         func() (map[string]struct{}, error)
+	readBaseFile func(string) ([]byte, error)
+}
+
+// ReadBaseFile reads a file at the git merge-base. It satisfies the
+// BaseFileReader interface when the differ was created via NewGitDiffer.
+func (d *differ) ReadBaseFile(relativePath string) ([]byte, error) {
+	if d.readBaseFile == nil {
+		return nil, fmt.Errorf("BaseFileReader not available (not a git differ)")
+	}
+	return d.readBaseFile(relativePath)
 }
 
 // git implements the Differ interface using a git version control method.
@@ -88,6 +104,9 @@ type git struct {
 	onceDiff       sync.Once
 	changedFiles   map[string]struct{}
 	diffErr        error
+	// root and baseRef are populated during diff() for use by readBaseFile.
+	root    string
+	baseRef string
 }
 
 // A Directory describes changes to a directory and its contents.
@@ -172,6 +191,7 @@ func (g *git) diff() (map[string]struct{}, error) {
 				return nil, err
 			}
 			root := strings.TrimSpace(string(out))
+			g.root = root
 			// get the revision from which HEAD was branched from g.baseBranch.
 			parent1, err := g.branchPointOf("HEAD")
 			if err != nil {
@@ -186,6 +206,8 @@ func (g *git) diff() (map[string]struct{}, error) {
 			if parent1 == "" {
 				parent1 = g.baseBranch
 			}
+
+			g.baseRef = parent1
 
 			rightwardParents := []string{"HEAD"}
 			if g.useMergeCommit {
@@ -297,6 +319,23 @@ func (g *git) branchPointOf(branch string) (string, error) {
 
 type fileDiffer struct {
 	changedFiles map[string]struct{}
+}
+
+// readBaseFile reads a file at the base ref using git show.
+// diff() must have been called first to populate root and baseRef.
+func (g *git) readBaseFile(relativePath string) ([]byte, error) {
+	// Ensure diff has been called to populate baseRef
+	if _, err := g.diff(); err != nil {
+		return nil, err
+	}
+	if g.baseRef == "" {
+		return nil, fmt.Errorf("no base ref available")
+	}
+	out, err := execWithStderr(exec.Command("git", "-C", g.root, "show", g.baseRef+":"+relativePath))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s at %s: %w", relativePath, g.baseRef, err)
+	}
+	return out, nil
 }
 
 func execWithStderr(c *exec.Cmd) (out []byte, err error) {

--- a/differ.go
+++ b/differ.go
@@ -193,6 +193,9 @@ func (g *git) diff() (map[string]struct{}, error) {
 				return nil, err
 			}
 			root := strings.TrimSpace(string(out))
+			if resolved, err := filepath.EvalSymlinks(root); err == nil {
+				root = resolved
+			}
 			g.root = root
 			// get the revision from which HEAD was branched from g.baseBranch.
 			parent1, err := g.branchPointOf("HEAD")

--- a/differ.go
+++ b/differ.go
@@ -31,8 +31,10 @@ type Differ interface {
 }
 
 // BaseFileReader provides access to file content at the base branch/commit.
+// The argument is an absolute path inside the repository; implementations
+// resolve it against the repository root.
 type BaseFileReader interface {
-	ReadBaseFile(relativePath string) ([]byte, error)
+	ReadBaseFile(absPath string) ([]byte, error)
 }
 
 // GitDifferOption is an option function used to modify a git differ
@@ -90,11 +92,11 @@ type differ struct {
 
 // ReadBaseFile reads a file at the git merge-base. It satisfies the
 // BaseFileReader interface when the differ was created via NewGitDiffer.
-func (d *differ) ReadBaseFile(relativePath string) ([]byte, error) {
+func (d *differ) ReadBaseFile(absPath string) ([]byte, error) {
 	if d.readBaseFile == nil {
 		return nil, fmt.Errorf("BaseFileReader not available (not a git differ)")
 	}
-	return d.readBaseFile(relativePath)
+	return d.readBaseFile(absPath)
 }
 
 // git implements the Differ interface using a git version control method.
@@ -321,19 +323,26 @@ type fileDiffer struct {
 	changedFiles map[string]struct{}
 }
 
-// readBaseFile reads a file at the base ref using git show.
-// diff() must have been called first to populate root and baseRef.
-func (g *git) readBaseFile(relativePath string) ([]byte, error) {
-	// Ensure diff has been called to populate baseRef
+// readBaseFile reads a file at the base ref using git show. The absolute
+// path is resolved against the repository toplevel, which diff() populates.
+func (g *git) readBaseFile(absPath string) ([]byte, error) {
+	// Ensure diff has been called to populate root and baseRef
 	if _, err := g.diff(); err != nil {
 		return nil, err
 	}
 	if g.baseRef == "" {
 		return nil, fmt.Errorf("no base ref available")
 	}
-	out, err := execWithStderr(exec.Command("git", "-C", g.root, "show", g.baseRef+":"+relativePath))
+	rel, err := filepath.Rel(g.root, absPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s at %s: %w", relativePath, g.baseRef, err)
+		return nil, fmt.Errorf("resolving %q against repository root %q: %w", absPath, g.root, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("path %q is outside repository %q", absPath, g.root)
+	}
+	out, err := execWithStderr(exec.Command("git", "-C", g.root, "show", g.baseRef+":"+filepath.ToSlash(rel)))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s at %s: %w", rel, g.baseRef, err)
 	}
 	return out, nil
 }

--- a/differ_test.go
+++ b/differ_test.go
@@ -16,6 +16,24 @@ import (
 // check to make sure Git implements the Differ interface.
 var _ Differ = &differ{}
 
+func TestBaseFileReaderInterface(t *testing.T) {
+	// NewGitDiffer returns a differ that satisfies BaseFileReader
+	gitDiffer := NewGitDiffer()
+	if _, ok := gitDiffer.(BaseFileReader); !ok {
+		t.Error("git differ should implement BaseFileReader")
+	}
+
+	// NewFileDiffer returns a differ that satisfies BaseFileReader structurally
+	// but its ReadBaseFile returns an error since there's no git backing.
+	fileDiffer := NewFileDiffer(nil)
+	if reader, ok := fileDiffer.(BaseFileReader); ok {
+		_, err := reader.ReadBaseFile("go.mod")
+		if err == nil {
+			t.Error("file differ's ReadBaseFile should return an error")
+		}
+	}
+}
+
 func Test_diffFileDirectories(t *testing.T) {
 	var tests = []struct {
 		desc string

--- a/differ_test.go
+++ b/differ_test.go
@@ -27,7 +27,7 @@ func TestBaseFileReaderInterface(t *testing.T) {
 	// but its ReadBaseFile returns an error since there's no git backing.
 	fileDiffer := NewFileDiffer(nil)
 	if reader, ok := fileDiffer.(BaseFileReader); ok {
-		_, err := reader.ReadBaseFile("go.mod")
+		_, err := reader.ReadBaseFile("/some/abs/path/go.mod")
 		if err == nil {
 			t.Error("file differ's ReadBaseFile should return an error")
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.25
 
 require (
 	github.com/google/go-cmp v0.7.0
+	golang.org/x/mod v0.33.0
 	golang.org/x/term v0.40.0
 	golang.org/x/tools v0.42.0
 	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated
 )
 
 require (
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect

--- a/gomod.go
+++ b/gomod.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2016 The gta AUTHORS. All rights reserved.
+
+Use of this source code is governed by the Apache 2 license that can be found
+in the LICENSE file.
+*/
+package gta
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// ModuleChange describes a change to a dependency module.
+type ModuleChange struct {
+	Path       string // module path, e.g. "golang.org/x/text"
+	OldVersion string // empty if newly added
+	NewVersion string // empty if removed
+}
+
+// parseGoMod attempts to parse go.mod data, trying strict Parse first
+// (which handles Replace directives) and falling back to ParseLax.
+func parseGoMod(name string, data []byte) (*modfile.File, error) {
+	f, err := modfile.Parse(name, data, nil)
+	if err != nil {
+		// Fall back to ParseLax which is more lenient with version strings
+		f, err = modfile.ParseLax(name, data, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return f, nil
+}
+
+// diffGoMod compares two go.mod file contents and returns the modules
+// whose versions changed, were added, or were removed.
+func diffGoMod(oldData, newData []byte) ([]ModuleChange, error) {
+	oldFile, err := parseGoMod("old/go.mod", oldData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing old go.mod: %w", err)
+	}
+	newFile, err := parseGoMod("new/go.mod", newData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing new go.mod: %w", err)
+	}
+
+	oldReqs := make(map[string]string)
+	for _, r := range oldFile.Require {
+		oldReqs[r.Mod.Path] = r.Mod.Version
+	}
+
+	newReqs := make(map[string]string)
+	for _, r := range newFile.Require {
+		newReqs[r.Mod.Path] = r.Mod.Version
+	}
+
+	var changes []ModuleChange
+
+	// Changed or added
+	for path, newVer := range newReqs {
+		oldVer, existed := oldReqs[path]
+		if !existed {
+			changes = append(changes, ModuleChange{Path: path, NewVersion: newVer})
+		} else if oldVer != newVer {
+			changes = append(changes, ModuleChange{Path: path, OldVersion: oldVer, NewVersion: newVer})
+		}
+	}
+
+	// Removed
+	for path, oldVer := range oldReqs {
+		if _, exists := newReqs[path]; !exists {
+			changes = append(changes, ModuleChange{Path: path, OldVersion: oldVer})
+		}
+	}
+
+	// Also diff Replace directives
+	oldReplace := make(map[string]string)
+	for _, r := range oldFile.Replace {
+		key := r.Old.Path + "@" + r.Old.Version
+		oldReplace[key] = r.New.Path + "@" + r.New.Version
+	}
+	newReplace := make(map[string]string)
+	for _, r := range newFile.Replace {
+		key := r.Old.Path + "@" + r.Old.Version
+		newReplace[key] = r.New.Path + "@" + r.New.Version
+	}
+	for key, newTarget := range newReplace {
+		oldTarget, existed := oldReplace[key]
+		modPath := strings.SplitN(key, "@", 2)[0]
+		if !existed || oldTarget != newTarget {
+			changes = append(changes, ModuleChange{Path: modPath})
+		}
+	}
+	for key := range oldReplace {
+		if _, exists := newReplace[key]; !exists {
+			modPath := strings.SplitN(key, "@", 2)[0]
+			changes = append(changes, ModuleChange{Path: modPath})
+		}
+	}
+
+	return changes, nil
+}
+
+// diffGoSum compares two go.sum file contents and returns the module
+// paths whose resolved versions changed. This captures transitive
+// dependency changes that go.mod diff alone would miss.
+func diffGoSum(oldData, newData []byte) []string {
+	oldEntries := parseGoSumEntries(oldData)
+	newEntries := parseGoSumEntries(newData)
+
+	changed := make(map[string]struct{})
+
+	// New or changed entries
+	for key := range newEntries {
+		if _, ok := oldEntries[key]; !ok {
+			modPath := goSumModulePath(key)
+			changed[modPath] = struct{}{}
+		}
+	}
+
+	// Removed entries
+	for key := range oldEntries {
+		if _, ok := newEntries[key]; !ok {
+			modPath := goSumModulePath(key)
+			changed[modPath] = struct{}{}
+		}
+	}
+
+	var result []string
+	for modPath := range changed {
+		result = append(result, modPath)
+	}
+	return result
+}
+
+// parseGoSumEntries parses go.sum content into a set of
+// "module version hash" lines for comparison.
+func parseGoSumEntries(data []byte) map[string]struct{} {
+	entries := make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		entries[line] = struct{}{}
+	}
+	return entries
+}
+
+// goSumModulePath extracts the module path from a go.sum line.
+// A go.sum line has the format: "module version hash"
+func goSumModulePath(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) >= 1 {
+		return fields[0]
+	}
+	return line
+}

--- a/gomod_test.go
+++ b/gomod_test.go
@@ -1,0 +1,193 @@
+package gta
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDiffGoMod(t *testing.T) {
+	tests := []struct {
+		name    string
+		old     string
+		new     string
+		want    []ModuleChange
+		wantErr bool
+	}{
+		{
+			name: "version bump",
+			old:  "module test\ngo 1.21\nrequire foo v1.0.0\n",
+			new:  "module test\ngo 1.21\nrequire foo v1.1.0\n",
+			want: []ModuleChange{{Path: "foo", OldVersion: "v1.0.0", NewVersion: "v1.1.0"}},
+		},
+		{
+			name: "dependency added",
+			old:  "module test\ngo 1.21\n",
+			new:  "module test\ngo 1.21\nrequire bar v1.0.0\n",
+			want: []ModuleChange{{Path: "bar", NewVersion: "v1.0.0"}},
+		},
+		{
+			name: "dependency removed",
+			old:  "module test\ngo 1.21\nrequire baz v1.0.0\n",
+			new:  "module test\ngo 1.21\n",
+			want: []ModuleChange{{Path: "baz", OldVersion: "v1.0.0"}},
+		},
+		{
+			name: "no change",
+			old:  "module test\ngo 1.21\nrequire foo v1.0.0\n",
+			new:  "module test\ngo 1.21\nrequire foo v1.0.0\n",
+			want: nil,
+		},
+		{
+			name: "multiple changes",
+			old:  "module test\ngo 1.21\nrequire (\n\ta v1.0.0\n\tb v1.0.0\n\tc v1.0.0\n)\n",
+			new:  "module test\ngo 1.21\nrequire (\n\ta v1.1.0\n\tb v1.2.0\n\td v1.0.0\n)\n",
+			want: []ModuleChange{
+				{Path: "a", OldVersion: "v1.0.0", NewVersion: "v1.1.0"},
+				{Path: "b", OldVersion: "v1.0.0", NewVersion: "v1.2.0"},
+				{Path: "d", NewVersion: "v1.0.0"},
+				{Path: "c", OldVersion: "v1.0.0"},
+			},
+		},
+		{
+			name: "indirect to direct same version",
+			old:  "module test\ngo 1.21\nrequire foo v1.0.0 // indirect\n",
+			new:  "module test\ngo 1.21\nrequire foo v1.0.0\n",
+			want: nil,
+		},
+		{
+			name: "replace added with version",
+			old:  "module test\ngo 1.21\nrequire foo v1.0.0\n",
+			new:  "module test\ngo 1.21\nrequire foo v1.0.0\nreplace foo v1.0.0 => bar v1.0.0\n",
+			want: []ModuleChange{{Path: "foo"}},
+		},
+		{
+			name: "replace version changed",
+			old:  "module test\ngo 1.21\nrequire foo v1.0.0\nreplace foo v1.0.0 => bar v1.0.0\n",
+			new:  "module test\ngo 1.21\nrequire foo v1.0.0\nreplace foo v1.0.0 => bar v1.1.0\n",
+			want: []ModuleChange{{Path: "foo"}},
+		},
+		{
+			name: "replace removed with version",
+			old:  "module test\ngo 1.21\nrequire foo v1.0.0\nreplace foo v1.0.0 => bar v1.0.0\n",
+			new:  "module test\ngo 1.21\nrequire foo v1.0.0\n",
+			want: []ModuleChange{{Path: "foo"}},
+		},
+		{
+			name: "both empty modules",
+			old:  "module test\ngo 1.21\n",
+			new:  "module test\ngo 1.21\n",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := diffGoMod([]byte(tt.old), []byte(tt.new))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Sort both for deterministic comparison
+			sortChanges := func(sl []ModuleChange) {
+				sort.Slice(sl, func(i, j int) bool {
+					return sl[i].Path < sl[j].Path
+				})
+			}
+			sortChanges(got)
+			sortChanges(tt.want)
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("(-want, +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDiffGoSum(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want []string
+	}{
+		{
+			name: "version added",
+			old:  "",
+			new:  "golang.org/x/text v0.4.0 h1:abc\n",
+			want: []string{"golang.org/x/text"},
+		},
+		{
+			name: "hash changed",
+			old:  "x/text v0.3.0 h1:abc\n",
+			new:  "x/text v0.3.0 h1:def\n",
+			want: []string{"x/text"},
+		},
+		{
+			name: "version removed",
+			old:  "x/text v0.3.0 h1:abc\n",
+			new:  "",
+			want: []string{"x/text"},
+		},
+		{
+			name: "no change",
+			old:  "x/text v0.3.0 h1:abc\n",
+			new:  "x/text v0.3.0 h1:abc\n",
+			want: nil,
+		},
+		{
+			name: "transitive dep added",
+			old:  "a v1.0.0 h1:x\n",
+			new:  "a v1.0.0 h1:x\nb v1.0.0 h1:y\n",
+			want: []string{"b"},
+		},
+		{
+			name: "multiple changes",
+			old:  "a v1.0.0 h1:x\nc v1.0.0 h1:z\n",
+			new:  "a v2.0.0 h1:y\nc v2.0.0 h1:w\n",
+			want: []string{"a", "c"},
+		},
+		{
+			name: "both empty",
+			old:  "",
+			new:  "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diffGoSum([]byte(tt.old), []byte(tt.new))
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("(-want, +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGoSumModulePath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"golang.org/x/text v0.4.0 h1:abc", "golang.org/x/text"},
+		{"foo v1.0.0/go.mod h1:abc", "foo"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := goSumModulePath(tt.input)
+		if got != tt.want {
+			t.Errorf("goSumModulePath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/gta.go
+++ b/gta.go
@@ -265,19 +265,24 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 	onlyTestsAffected := make(map[string]struct{})
 	onlyTestPackagesChanged := make(map[string]struct{})
 	for abs, dir := range dirs {
-		// TODO(bc): handle changes to go.mod when vendoring is not being used.
-
-		// When go.work or go.mod changes, the dependency graph may have changed
-		// significantly. Mark all resolvable packages that match our prefix
-		// filter as changed so their dependents will be re-evaluated.
-		hasModuleConfig := false
+		// Detect changes to module configuration files.
+		hasGoWork := false
+		hasGoMod := false
+		hasGoSum := false
 		for _, f := range dir.Files {
-			if f == "go.work" || f == "go.mod" {
-				hasModuleConfig = true
-				break
+			switch f {
+			case "go.work":
+				hasGoWork = true
+			case "go.mod":
+				hasGoMod = true
+			case "go.sum":
+				hasGoSum = true
 			}
 		}
-		if hasModuleConfig {
+
+		// go.work changes always use the nuclear option -- workspace structural
+		// changes warrant full re-evaluation.
+		if hasGoWork {
 			graph, err := g.packager.DependentGraph()
 			if err == nil {
 				for pkg := range graph.graph {
@@ -289,8 +294,87 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 					}
 				}
 			}
-			// If this directory has no Go files (e.g. workspace root with
-			// only go.work), skip further package-level processing.
+			if !hasGoFile(dir.Files) {
+				continue
+			}
+		}
+
+		// For go.mod/go.sum changes, attempt precise dependency diff analysis.
+		if hasGoMod || hasGoSum {
+			var changedModPaths []string
+			preciseDetection := false
+
+			// Strategy 1: Use BaseFileReader (git differ) to get old content
+			if baseReader, ok := g.differ.(BaseFileReader); ok {
+				if hasGoMod {
+					relPath := relativeModFilePath(abs, g.roots, "go.mod")
+					oldData, err := baseReader.ReadBaseFile(relPath)
+					if err == nil && oldData != nil {
+						newData, _ := os.ReadFile(filepath.Join(abs, "go.mod"))
+						if changes, err := diffGoMod(oldData, newData); err == nil {
+							for _, mc := range changes {
+								changedModPaths = append(changedModPaths, mc.Path)
+							}
+							preciseDetection = true
+						}
+					}
+				}
+				if hasGoSum {
+					relPath := relativeModFilePath(abs, g.roots, "go.sum")
+					oldData, err := baseReader.ReadBaseFile(relPath)
+					if err == nil && oldData != nil {
+						newData, _ := os.ReadFile(filepath.Join(abs, "go.sum"))
+						sumPaths := diffGoSum(oldData, newData)
+						changedModPaths = append(changedModPaths, sumPaths...)
+						preciseDetection = true
+					}
+				}
+			}
+
+			// Strategy 2: Use provided base files (file-differ mode)
+			if !preciseDetection && (g.baseGoMod != "" || g.baseGoSum != "") {
+				if g.baseGoMod != "" && hasGoMod {
+					oldData, _ := os.ReadFile(g.baseGoMod)
+					newData, _ := os.ReadFile(filepath.Join(abs, "go.mod"))
+					if changes, err := diffGoMod(oldData, newData); err == nil {
+						for _, mc := range changes {
+							changedModPaths = append(changedModPaths, mc.Path)
+						}
+						preciseDetection = true
+					}
+				}
+				if g.baseGoSum != "" && hasGoSum {
+					oldData, _ := os.ReadFile(g.baseGoSum)
+					newData, _ := os.ReadFile(filepath.Join(abs, "go.sum"))
+					sumPaths := diffGoSum(oldData, newData)
+					changedModPaths = append(changedModPaths, sumPaths...)
+					preciseDetection = true
+				}
+			}
+
+			// Apply results
+			if preciseDetection && len(changedModPaths) > 0 {
+				changedModPaths = dedup(changedModPaths)
+				if finder, ok := g.packager.(localImporterFinder); ok {
+					for _, importerPath := range finder.LocalImportersOf(changedModPaths) {
+						changed[importerPath] = false
+					}
+				}
+			} else if !preciseDetection {
+				// Fallback: no base available -- use nuclear option (existing behavior)
+				graph, err := g.packager.DependentGraph()
+				if err == nil {
+					for pkg := range graph.graph {
+						if !hasPrefixIn(pkg, g.prefixes) {
+							continue
+						}
+						if _, err := g.packager.PackageFromImport(pkg); err == nil {
+							changed[pkg] = false
+						}
+					}
+				}
+			}
+
 			if !hasGoFile(dir.Files) {
 				continue
 			}
@@ -501,6 +585,41 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 // by custom Packager implementations.
 type localPackageChecker interface {
 	isLocalPackage(string) bool
+}
+
+// localImporterFinder is satisfied by packageContext but not required
+// by custom Packager implementations.
+type localImporterFinder interface {
+	LocalImportersOf(modulePaths []string) []string
+}
+
+// dedup removes duplicate strings from a slice.
+func dedup(sl []string) []string {
+	seen := make(map[string]struct{}, len(sl))
+	result := make([]string, 0, len(sl))
+	for _, s := range sl {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		result = append(result, s)
+	}
+	return result
+}
+
+// relativeModFilePath computes the git-relative path to a module file
+// (go.mod or go.sum) given the absolute directory and the repository roots.
+func relativeModFilePath(absDir string, roots []string, filename string) string {
+	for _, root := range roots {
+		if strings.HasPrefix(absDir, root) {
+			rel, err := filepath.Rel(root, absDir)
+			if err == nil {
+				return filepath.Join(rel, filename)
+			}
+		}
+	}
+	// Fallback: just use the filename
+	return filename
 }
 
 var errImportPathNotFound = errors.New("could not find import path")

--- a/gta.go
+++ b/gta.go
@@ -443,6 +443,7 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 		// Traverse dependents. When includeTransitiveTestDeps is true, test-only
 		// edges are traversed the same as production edges (replicating the old
 		// behavior where all imports were in a single reverse graph).
+		checker, hasChecker := g.packager.(localPackageChecker)
 		var traverse func(node string)
 		traverse = func(node string) {
 			if marked[node] {
@@ -452,12 +453,19 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 
 			if edges, ok := graph.graph[node]; ok {
 				for edge := range edges {
+					// Skip non-local dependents if the packager supports the check
+					if hasChecker && !checker.isLocalPackage(edge) {
+						continue
+					}
 					traverse(edge)
 				}
 			}
 			if g.includeTransitiveTestDeps {
 				if edges, ok := testOnlyGraph.graph[node]; ok {
 					for edge := range edges {
+						if hasChecker && !checker.isLocalPackage(edge) {
+							continue
+						}
 						traverse(edge)
 					}
 				}
@@ -485,6 +493,12 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 	}
 
 	return paths, nil
+}
+
+// localPackageChecker is satisfied by packageContext but not required
+// by custom Packager implementations.
+type localPackageChecker interface {
+	isLocalPackage(string) bool
 }
 
 var errImportPathNotFound = errors.New("could not find import path")

--- a/gta.go
+++ b/gta.go
@@ -199,7 +199,9 @@ func (g *GTA) ChangedPackages() (*Packages, error) {
 			if check {
 				pkg2, err := packageFromImport(path)
 				if err != nil {
-					return nil, err
+					// Package cannot be resolved -- likely an external
+					// dependency not in the local module. Skip it.
+					continue
 				}
 				pkg = pkg2
 			}

--- a/gta.go
+++ b/gta.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/mod/modfile"
 )
 
 var (
@@ -93,6 +95,7 @@ type GTA struct {
 	tags                      []string
 	roots                     []string
 	includeTransitiveTestDeps bool
+	disableWorkspace          bool
 }
 
 // New returns a new GTA with various options passed to New. Options will be
@@ -111,7 +114,7 @@ func New(opts ...Option) (*GTA, error) {
 	}
 
 	if gta.roots == nil {
-		roots, err := toplevel()
+		roots, err := toplevel(gta.disableWorkspace)
 		if err != nil {
 			return nil, fmt.Errorf("could not get top level directory")
 		}
@@ -137,7 +140,7 @@ func New(opts ...Option) (*GTA, error) {
 		// when a file is changed. e.g. if a vendored file that is constrained to
 		// Windows is changed, that package wouldn't load at all and trying to find
 		// the package's dependencies would fail.
-		gta.packager = NewPackager(nil, gta.tags)
+		gta.packager = NewPackager(nil, gta.tags, gta.disableWorkspace)
 	}
 
 	return gta, nil
@@ -259,6 +262,35 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 	onlyTestPackagesChanged := make(map[string]struct{})
 	for abs, dir := range dirs {
 		// TODO(bc): handle changes to go.mod when vendoring is not being used.
+
+		// When go.work or go.mod changes, the dependency graph may have changed
+		// significantly. Mark all resolvable packages that match our prefix
+		// filter as changed so their dependents will be re-evaluated.
+		hasModuleConfig := false
+		for _, f := range dir.Files {
+			if f == "go.work" || f == "go.mod" {
+				hasModuleConfig = true
+				break
+			}
+		}
+		if hasModuleConfig {
+			graph, err := g.packager.DependentGraph()
+			if err == nil {
+				for pkg := range graph.graph {
+					if !hasPrefixIn(pkg, g.prefixes) {
+						continue
+					}
+					if _, err := g.packager.PackageFromImport(pkg); err == nil {
+						changed[pkg] = false
+					}
+				}
+			}
+			// If this directory has no Go files (e.g. workspace root with
+			// only go.work), skip further package-level processing.
+			if !hasGoFile(dir.Files) {
+				continue
+			}
+		}
 
 		// Add packages that embed the files of dir.
 		for _, f := range dir.Files {
@@ -599,17 +631,67 @@ func hasOnlyTestFilenames(sl []string) bool {
 	return true
 }
 
-func toplevel() ([]string, error) {
+func toplevel(disableWorkspace bool) ([]string, error) {
 	if os.Getenv("GO111MODULE") == "off" {
 		return gopaths()
 	}
 
-	root, err := moduleroot()
+	if !disableWorkspace {
+		roots, err := workspaceroots()
+		if err != nil {
+			return nil, err
+		}
+		if roots != nil {
+			return roots, nil
+		}
+	}
+
+	root, err := moduleroot(disableWorkspace)
 	if err != nil {
 		return nil, err
 	}
 	return []string{root}, nil
+}
 
+// workspaceroots detects whether the current directory is within a Go
+// workspace (go.work) and returns the absolute paths of all workspace module
+// directories. It returns nil, nil when not in workspace mode.
+func workspaceroots() ([]string, error) {
+	cmd := exec.Command("go", "env", "GOWORK")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("could not get GOWORK: %w", err)
+	}
+	gowork := strings.TrimSpace(string(b))
+	if gowork == "" || gowork == "off" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(gowork)
+	if err != nil {
+		return nil, fmt.Errorf("could not read go.work file %q: %w", gowork, err)
+	}
+
+	workFile, err := modfile.ParseWork(gowork, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse go.work file %q: %w", gowork, err)
+	}
+
+	workDir := filepath.Dir(gowork)
+	var roots []string
+	for _, use := range workFile.Use {
+		absDir, err := filepath.Abs(filepath.Join(workDir, use.Path))
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve workspace module path %q: %w", use.Path, err)
+		}
+		roots = append(roots, absDir)
+	}
+
+	if len(roots) == 0 {
+		return nil, nil
+	}
+
+	return roots, nil
 }
 
 func gopaths() ([]string, error) {
@@ -626,8 +708,11 @@ func gopaths() ([]string, error) {
 	return roots, nil
 }
 
-func moduleroot() (string, error) {
+func moduleroot(disableWorkspace bool) (string, error) {
 	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}")
+	if disableWorkspace {
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+	}
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("could get not get module root: %w", err)

--- a/gta.go
+++ b/gta.go
@@ -96,6 +96,8 @@ type GTA struct {
 	roots                     []string
 	includeTransitiveTestDeps bool
 	disableWorkspace          bool
+	baseGoMod                 string
+	baseGoSum                 string
 }
 
 // New returns a new GTA with various options passed to New. Options will be

--- a/gta.go
+++ b/gta.go
@@ -262,7 +262,120 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 	onlyTestsAffected := make(map[string]struct{})
 	onlyTestPackagesChanged := make(map[string]struct{})
 	for abs, dir := range dirs {
-		// TODO(bc): handle changes to go.mod when vendoring is not being used.
+		// Detect changes to module configuration files.
+		hasGoWork := false
+		hasGoMod := false
+		hasGoSum := false
+		for _, f := range dir.Files {
+			switch f {
+			case "go.work":
+				hasGoWork = true
+			case "go.mod":
+				hasGoMod = true
+			case "go.sum":
+				hasGoSum = true
+			}
+		}
+
+		// go.work changes always use the nuclear option -- workspace structural
+		// changes warrant full re-evaluation.
+		if hasGoWork {
+			graph, err := g.packager.DependentGraph()
+			if err == nil {
+				for pkg := range graph.graph {
+					if !hasPrefixIn(pkg, g.prefixes) {
+						continue
+					}
+					if _, err := g.packager.PackageFromImport(pkg); err == nil {
+						changed[pkg] = false
+					}
+				}
+			}
+			if !hasGoFile(dir.Files) {
+				continue
+			}
+		}
+
+		// For go.mod/go.sum changes, attempt precise dependency diff analysis.
+		if hasGoMod || hasGoSum {
+			var changedModPaths []string
+			preciseDetection := false
+
+			// Strategy 1: Use BaseFileReader (git differ) to get old content
+			if baseReader, ok := g.differ.(BaseFileReader); ok {
+				if hasGoMod {
+					relPath := relativeModFilePath(abs, g.roots, "go.mod")
+					oldData, err := baseReader.ReadBaseFile(relPath)
+					if err == nil && oldData != nil {
+						newData, _ := os.ReadFile(filepath.Join(abs, "go.mod"))
+						if changes, err := diffGoMod(oldData, newData); err == nil {
+							for _, mc := range changes {
+								changedModPaths = append(changedModPaths, mc.Path)
+							}
+							preciseDetection = true
+						}
+					}
+				}
+				if hasGoSum {
+					relPath := relativeModFilePath(abs, g.roots, "go.sum")
+					oldData, err := baseReader.ReadBaseFile(relPath)
+					if err == nil && oldData != nil {
+						newData, _ := os.ReadFile(filepath.Join(abs, "go.sum"))
+						sumPaths := diffGoSum(oldData, newData)
+						changedModPaths = append(changedModPaths, sumPaths...)
+						preciseDetection = true
+					}
+				}
+			}
+
+			// Strategy 2: Use provided base files (file-differ mode)
+			if !preciseDetection && (g.baseGoMod != "" || g.baseGoSum != "") {
+				if g.baseGoMod != "" && hasGoMod {
+					oldData, _ := os.ReadFile(g.baseGoMod)
+					newData, _ := os.ReadFile(filepath.Join(abs, "go.mod"))
+					if changes, err := diffGoMod(oldData, newData); err == nil {
+						for _, mc := range changes {
+							changedModPaths = append(changedModPaths, mc.Path)
+						}
+						preciseDetection = true
+					}
+				}
+				if g.baseGoSum != "" && hasGoSum {
+					oldData, _ := os.ReadFile(g.baseGoSum)
+					newData, _ := os.ReadFile(filepath.Join(abs, "go.sum"))
+					sumPaths := diffGoSum(oldData, newData)
+					changedModPaths = append(changedModPaths, sumPaths...)
+					preciseDetection = true
+				}
+			}
+
+			// Apply results
+			if preciseDetection && len(changedModPaths) > 0 {
+				changedModPaths = dedup(changedModPaths)
+				if finder, ok := g.packager.(localImporterFinder); ok {
+					for _, importerPath := range finder.LocalImportersOf(changedModPaths) {
+						changed[importerPath] = false
+					}
+				}
+			} else if !preciseDetection {
+				// Fallback: no base available -- use nuclear option (existing behavior)
+				graph, err := g.packager.DependentGraph()
+				if err == nil {
+					for pkg := range graph.graph {
+						if !hasPrefixIn(pkg, g.prefixes) {
+							continue
+						}
+						if _, err := g.packager.PackageFromImport(pkg); err == nil {
+							changed[pkg] = false
+						}
+					}
+				}
+			}
+
+			if !hasGoFile(dir.Files) {
+				continue
+			}
+		}
 
 		// Add packages that embed the files of dir.
 		for _, f := range dir.Files {
@@ -469,6 +582,41 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 // by custom Packager implementations.
 type localPackageChecker interface {
 	isLocalPackage(string) bool
+}
+
+// localImporterFinder is satisfied by packageContext but not required
+// by custom Packager implementations.
+type localImporterFinder interface {
+	LocalImportersOf(modulePaths []string) []string
+}
+
+// dedup removes duplicate strings from a slice.
+func dedup(sl []string) []string {
+	seen := make(map[string]struct{}, len(sl))
+	result := make([]string, 0, len(sl))
+	for _, s := range sl {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		result = append(result, s)
+	}
+	return result
+}
+
+// relativeModFilePath computes the git-relative path to a module file
+// (go.mod or go.sum) given the absolute directory and the repository roots.
+func relativeModFilePath(absDir string, roots []string, filename string) string {
+	for _, root := range roots {
+		if strings.HasPrefix(absDir, root) {
+			rel, err := filepath.Rel(root, absDir)
+			if err == nil {
+				return filepath.Join(rel, filename)
+			}
+		}
+	}
+	// Fallback: just use the filename
+	return filename
 }
 
 var errImportPathNotFound = errors.New("could not find import path")

--- a/gta.go
+++ b/gta.go
@@ -304,8 +304,7 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 			// Strategy 1: Use BaseFileReader (git differ) to get old content
 			if baseReader, ok := g.differ.(BaseFileReader); ok {
 				if hasGoMod {
-					relPath := relativeModFilePath(abs, g.roots, "go.mod")
-					oldData, err := baseReader.ReadBaseFile(relPath)
+					oldData, err := baseReader.ReadBaseFile(filepath.Join(abs, "go.mod"))
 					if err == nil && oldData != nil {
 						newData, _ := os.ReadFile(filepath.Join(abs, "go.mod"))
 						if changes, err := diffGoMod(oldData, newData); err == nil {
@@ -317,8 +316,7 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 					}
 				}
 				if hasGoSum {
-					relPath := relativeModFilePath(abs, g.roots, "go.sum")
-					oldData, err := baseReader.ReadBaseFile(relPath)
+					oldData, err := baseReader.ReadBaseFile(filepath.Join(abs, "go.sum"))
 					if err == nil && oldData != nil {
 						newData, _ := os.ReadFile(filepath.Join(abs, "go.sum"))
 						sumPaths := diffGoSum(oldData, newData)
@@ -602,21 +600,6 @@ func dedup(sl []string) []string {
 		result = append(result, s)
 	}
 	return result
-}
-
-// relativeModFilePath computes the git-relative path to a module file
-// (go.mod or go.sum) given the absolute directory and the repository roots.
-func relativeModFilePath(absDir string, roots []string, filename string) string {
-	for _, root := range roots {
-		if strings.HasPrefix(absDir, root) {
-			rel, err := filepath.Rel(root, absDir)
-			if err == nil {
-				return filepath.Join(rel, filename)
-			}
-		}
-	}
-	// Fallback: just use the filename
-	return filename
 }
 
 var errImportPathNotFound = errors.New("could not find import path")

--- a/gta.go
+++ b/gta.go
@@ -196,7 +196,9 @@ func (g *GTA) ChangedPackages() (*Packages, error) {
 			if check {
 				pkg2, err := packageFromImport(path)
 				if err != nil {
-					return nil, err
+					// Package cannot be resolved -- likely an external
+					// dependency not in the local module. Skip it.
+					continue
 				}
 				pkg = pkg2
 			}

--- a/gta.go
+++ b/gta.go
@@ -93,6 +93,8 @@ type GTA struct {
 	tags                      []string
 	roots                     []string
 	includeTransitiveTestDeps bool
+	baseGoMod                 string
+	baseGoSum                 string
 }
 
 // New returns a new GTA with various options passed to New. Options will be

--- a/gta.go
+++ b/gta.go
@@ -115,7 +115,7 @@ func New(opts ...Option) (*GTA, error) {
 	if gta.roots == nil {
 		roots, err := toplevel()
 		if err != nil {
-			return nil, fmt.Errorf("could not get top level directory")
+			return nil, fmt.Errorf("could not get top level directory: %w", err)
 		}
 		gta.roots = roots
 	}

--- a/gta.go
+++ b/gta.go
@@ -118,6 +118,9 @@ func New(opts ...Option) (*GTA, error) {
 			return nil, fmt.Errorf("could not get top level directory: %w", err)
 		}
 		gta.roots = roots
+		for i, r := range gta.roots {
+			gta.roots[i] = canonicalDir(r)
+		}
 	}
 
 	// set the default packager after applying option so that the default
@@ -374,6 +377,15 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 				continue
 			}
 		}
+
+		// Canonicalize abs so that symlink-resolved module dirs (from
+		// packages.Load) and symlink-resolved roots (from toplevel) match the
+		// incoming path even when the differ supplies a path that passes through
+		// a symlink (e.g. macOS /tmp -> /private/tmp, container bind mounts).
+		// File operations above (go.mod/go.sum reads via ReadBaseFile, os.ReadFile)
+		// intentionally used the raw path so that the differ's root-relative
+		// resolution still works; from this point forward we need canonical form.
+		abs = canonicalDir(abs)
 
 		// Add packages that embed the files of dir.
 		for _, f := range dir.Files {

--- a/gta.go
+++ b/gta.go
@@ -411,6 +411,7 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 		// Traverse dependents. When includeTransitiveTestDeps is true, test-only
 		// edges are traversed the same as production edges (replicating the old
 		// behavior where all imports were in a single reverse graph).
+		checker, hasChecker := g.packager.(localPackageChecker)
 		var traverse func(node string)
 		traverse = func(node string) {
 			if marked[node] {
@@ -420,12 +421,19 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 
 			if edges, ok := graph.graph[node]; ok {
 				for edge := range edges {
+					// Skip non-local dependents if the packager supports the check
+					if hasChecker && !checker.isLocalPackage(edge) {
+						continue
+					}
 					traverse(edge)
 				}
 			}
 			if g.includeTransitiveTestDeps {
 				if edges, ok := testOnlyGraph.graph[node]; ok {
 					for edge := range edges {
+						if hasChecker && !checker.isLocalPackage(edge) {
+							continue
+						}
 						traverse(edge)
 					}
 				}
@@ -453,6 +461,12 @@ func (g *GTA) markedPackages() (map[string]map[string]bool, error) {
 	}
 
 	return paths, nil
+}
+
+// localPackageChecker is satisfied by packageContext but not required
+// by custom Packager implementations.
+type localPackageChecker interface {
+	isLocalPackage(string) bool
 }
 
 var errImportPathNotFound = errors.New("could not find import path")

--- a/gta_test.go
+++ b/gta_test.go
@@ -725,6 +725,122 @@ func TestGTA_ChangedPackages(t *testing.T) {
 	})
 }
 
+func TestMarkedPackages_SkipsExternalDependents(t *testing.T) {
+	// When the packager implements localPackageChecker (as packageContext does),
+	// the traverse function in markedPackages should skip non-local edges.
+	// We use packageContext with a crafted graph to test this.
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{"/repo": "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"local/b": {}},
+			"local/b": {},
+		},
+		reverse: map[string]map[string]struct{}{
+			"local/b": {"local/a": {}, "external/pkg": {}},
+		},
+		testOnlyReverse: map[string]map[string]struct{}{},
+		packages:        make(map[string]struct{}),
+	}
+
+	// Verify packageContext satisfies localPackageChecker
+	if _, ok := interface{}(pc).(localPackageChecker); !ok {
+		t.Fatal("packageContext should implement localPackageChecker")
+	}
+
+	// Build the graph from reverse
+	graph, err := pc.DependentGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up differ that marks local/b as changed
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			"dirB": {Exists: true, Files: []string{"b.go"}},
+		},
+	}
+
+	// We need PackageFromDir to work for "dirB" → "local/b"
+	// Create a wrapper that delegates dir lookups but uses pc for graph/checker
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			"dirB": "local/b",
+		},
+	}
+	_ = graph // used by wrapper internally
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() returned unexpected error: %v", err)
+	}
+
+	// external/pkg should NOT appear in AllChanges
+	for _, p := range pkgs.AllChanges {
+		if p.ImportPath == "external/pkg" {
+			t.Error("external/pkg should not appear in AllChanges")
+		}
+	}
+
+	// local/a and local/b should be present
+	want := []string{"local/a", "local/b"}
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+// packageContextTestWrapper wraps a packageContext for testing, providing
+// both Packager and localPackageChecker interfaces.
+type packageContextTestWrapper struct {
+	pc           *packageContext
+	dirs2Imports map[string]string
+}
+
+func (w *packageContextTestWrapper) PackageFromDir(dir string) (*Package, error) {
+	ip, ok := w.dirs2Imports[dir]
+	if !ok {
+		return nil, fmt.Errorf("dir not found: %s", dir)
+	}
+	return &Package{ImportPath: ip}, nil
+}
+
+func (w *packageContextTestWrapper) PackageFromEmptyDir(dir string) (*Package, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (w *packageContextTestWrapper) PackageFromImport(importPath string) (*Package, error) {
+	if w.pc.isLocalPackage(importPath) {
+		return &Package{ImportPath: importPath, Dir: importPath}, nil
+	}
+	return nil, fmt.Errorf("package not found: %s", importPath)
+}
+
+func (w *packageContextTestWrapper) DependentGraph() (*Graph, error) {
+	return w.pc.DependentGraph()
+}
+
+func (w *packageContextTestWrapper) TestOnlyDependentGraph() (*Graph, error) {
+	return w.pc.TestOnlyDependentGraph()
+}
+
+func (w *packageContextTestWrapper) EmbeddedBy(_ string) []string {
+	return nil
+}
+
+func (w *packageContextTestWrapper) isLocalPackage(importPath string) bool {
+	return w.pc.isLocalPackage(importPath)
+}
+
 func TestChangedPackages_ExternalPackageSkipped(t *testing.T) {
 	// The reverse graph has an external package as a dependent of "C".
 	// PackageFromImport will fail for "external/pkg" since it's not in

--- a/gta_test.go
+++ b/gta_test.go
@@ -313,7 +313,7 @@ func TestGTA_ChangedPackages(t *testing.T) {
 			popd := chdir(t, exporter.Filename(e, testModule, ""))
 			t.Cleanup(popd)
 
-			cfg := newLoadConfig(nil)
+			cfg := newLoadConfig(nil, false)
 			e.Config.Mode = cfg.Mode
 			e.Config.BuildFlags = cfg.BuildFlags
 			e.Config.Tests = cfg.Tests

--- a/gta_test.go
+++ b/gta_test.go
@@ -841,6 +841,10 @@ func (w *packageContextTestWrapper) isLocalPackage(importPath string) bool {
 	return w.pc.isLocalPackage(importPath)
 }
 
+func (w *packageContextTestWrapper) LocalImportersOf(modulePaths []string) []string {
+	return w.pc.LocalImportersOf(modulePaths)
+}
+
 func TestChangedPackages_ExternalPackageSkipped(t *testing.T) {
 	// The reverse graph has an external package as a dependent of "C".
 	// PackageFromImport will fail for "external/pkg" since it's not in
@@ -1259,5 +1263,321 @@ func TestDeepestUnignoredDir(t *testing.T) {
 		if want := tt.expected; got != want {
 			t.Errorf("deepestUnignoredDir(%q) = %v; want %v", tt.in, got, want)
 		}
+	}
+}
+
+// testBaseFileReaderDiffer is a testDiffer that also implements BaseFileReader.
+type testBaseFileReaderDiffer struct {
+	testDiffer
+	baseFiles map[string][]byte
+}
+
+func (t *testBaseFileReaderDiffer) ReadBaseFile(relativePath string) ([]byte, error) {
+	data, ok := t.baseFiles[relativePath]
+	if !ok {
+		return nil, fmt.Errorf("file %s not found at base", relativePath)
+	}
+	return data, nil
+}
+
+func TestMarkedPackages_GoModChange_PreciseDetection(t *testing.T) {
+	// When go.mod changes and a BaseFileReader is available, only the local
+	// packages that import the changed dependency should be marked.
+	tmpDir := t.TempDir()
+
+	// Write new go.mod with a version bump for ext/foo
+	newGoMod := "module local\ngo 1.21\nrequire ext/foo v1.1.0\nrequire ext/bar v1.0.0\n"
+	os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(newGoMod), 0644)
+
+	oldGoMod := "module local\ngo 1.21\nrequire ext/foo v1.0.0\nrequire ext/bar v1.0.0\n"
+
+	difr := &testBaseFileReaderDiffer{
+		testDiffer: testDiffer{
+			diff: map[string]Directory{
+				tmpDir: {Exists: true, Files: []string{"go.mod"}},
+			},
+		},
+		baseFiles: map[string][]byte{
+			"go.mod": []byte(oldGoMod),
+		},
+	}
+
+	// Set up packager where local/a imports ext/foo, local/b does not
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{tmpDir: "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"ext/foo/sub": {}},
+			"local/b": {"ext/bar": {}},
+			"local/c": {},
+		},
+		reverse: map[string]map[string]struct{}{
+			"ext/foo/sub": {"local/a": {}},
+			"ext/bar":     {"local/b": {}},
+		},
+		testOnlyReverse:     map[string]map[string]struct{}{},
+		packages:            make(map[string]struct{}),
+		packagesByEmbedFile: make(map[string][]string),
+	}
+
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			tmpDir: "local",
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{tmpDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// Only local/a should be marked (it imports ext/foo)
+	// local/b and local/c should NOT be marked
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	want := []string{"local/a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+func TestMarkedPackages_GoModChange_FallbackToNuclear(t *testing.T) {
+	// When the differ does NOT implement BaseFileReader and no base options
+	// are set, fall back to the nuclear option (mark all packages).
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module local\ngo 1.21\n"), 0644)
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			tmpDir: {Exists: true, Files: []string{"go.mod"}},
+		},
+	}
+
+	graph := &Graph{
+		graph: map[string]map[string]bool{
+			"A": {"B": true},
+		},
+	}
+
+	pkgr := &testPackager{
+		dirs2Imports: map[string]string{
+			tmpDir: "local",
+			"dirA": "A",
+			"dirB": "B",
+		},
+		graph: graph,
+		errs:  make(map[string]error),
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(pkgr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{tmpDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// With nuclear option, A and B should be marked (from graph)
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	// Nuclear marks everything in the graph
+	if len(got) < 2 {
+		t.Errorf("expected nuclear option to mark multiple packages, got %v", got)
+	}
+}
+
+func TestMarkedPackages_GoSumChange_TransitiveDep(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Only go.sum changed (go.mod unchanged)
+	newGoSum := "ext/foo v1.1.0 h1:newhash\next/foo v1.1.0/go.mod h1:modhash\n"
+	os.WriteFile(filepath.Join(tmpDir, "go.sum"), []byte(newGoSum), 0644)
+
+	oldGoSum := "ext/foo v1.0.0 h1:oldhash\next/foo v1.0.0/go.mod h1:modhash\n"
+
+	difr := &testBaseFileReaderDiffer{
+		testDiffer: testDiffer{
+			diff: map[string]Directory{
+				tmpDir: {Exists: true, Files: []string{"go.sum"}},
+			},
+		},
+		baseFiles: map[string][]byte{
+			"go.sum": []byte(oldGoSum),
+		},
+	}
+
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{tmpDir: "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"ext/foo": {}},
+			"local/b": {"ext/bar": {}},
+		},
+		reverse: map[string]map[string]struct{}{
+			"ext/foo": {"local/a": {}},
+			"ext/bar": {"local/b": {}},
+		},
+		testOnlyReverse:     map[string]map[string]struct{}{},
+		packages:            make(map[string]struct{}),
+		packagesByEmbedFile: make(map[string][]string),
+	}
+
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			tmpDir: "local",
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{tmpDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	// Only local/a should be marked (imports ext/foo which changed in go.sum)
+	want := []string{"local/a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+func TestMarkedPackages_GoWorkChange_StillNuclear(t *testing.T) {
+	// go.work changes should still use the nuclear option
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			"dir": {Exists: true, Files: []string{"go.work"}},
+		},
+	}
+
+	graph := &Graph{
+		graph: map[string]map[string]bool{
+			"A": {"B": true},
+			"B": {},
+		},
+	}
+
+	pkgr := &testPackager{
+		dirs2Imports: map[string]string{
+			"dirA": "A",
+			"dirB": "B",
+		},
+		graph: graph,
+		errs:  make(map[string]error),
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(pkgr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// go.work change should mark all packages in the graph (nuclear)
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	want := []string{"A", "B"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+func TestMarkedPackages_BaseGoModOption(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write old and new go.mod files
+	oldGoMod := "module local\ngo 1.21\nrequire ext/foo v1.0.0\nrequire ext/bar v1.0.0\n"
+	newGoMod := "module local\ngo 1.21\nrequire ext/foo v1.1.0\nrequire ext/bar v1.0.0\n"
+
+	oldGoModPath := filepath.Join(tmpDir, "old_go.mod")
+	os.WriteFile(oldGoModPath, []byte(oldGoMod), 0644)
+
+	modDir := filepath.Join(tmpDir, "module")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "go.mod"), []byte(newGoMod), 0644)
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			modDir: {Exists: true, Files: []string{"go.mod"}},
+		},
+	}
+
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{modDir: "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"ext/foo": {}},
+			"local/b": {"ext/bar": {}},
+		},
+		reverse: map[string]map[string]struct{}{
+			"ext/foo": {"local/a": {}},
+			"ext/bar": {"local/b": {}},
+		},
+		testOnlyReverse:     map[string]map[string]struct{}{},
+		packages:            make(map[string]struct{}),
+		packagesByEmbedFile: make(map[string][]string),
+	}
+
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			modDir: "local",
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper), SetBaseGoMod(oldGoModPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{modDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	// Only local/a should be marked (imports ext/foo which changed)
+	want := []string{"local/a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
 	}
 }

--- a/gta_test.go
+++ b/gta_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -722,6 +723,68 @@ func TestGTA_ChangedPackages(t *testing.T) {
 
 		testChangedPackages(t, diff, nil, want)
 	})
+}
+
+func TestChangedPackages_ExternalPackageSkipped(t *testing.T) {
+	// The reverse graph has an external package as a dependent of "C".
+	// PackageFromImport will fail for "external/pkg" since it's not in
+	// dirs2Imports. ChangedPackages should succeed and skip the external package.
+	graph := &Graph{
+		graph: map[string]map[string]bool{
+			"C": {
+				"B":            true,
+				"external/pkg": true,
+			},
+			"B": {
+				"A": true,
+			},
+		},
+	}
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			"dirC": {Exists: true, Files: []string{"c.go"}},
+		},
+	}
+
+	pkgr := &testPackager{
+		dirs2Imports: map[string]string{
+			"dirA": "A",
+			"dirB": "B",
+			"dirC": "C",
+			// "external/pkg" deliberately absent
+		},
+		graph: graph,
+		errs:  make(map[string]error),
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(pkgr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() returned unexpected error: %v", err)
+	}
+
+	// external/pkg should NOT be in AllChanges
+	for _, p := range pkgs.AllChanges {
+		if p.ImportPath == "external/pkg" {
+			t.Error("external/pkg should not appear in AllChanges")
+		}
+	}
+
+	// A, B, C should be present
+	want := []string{"A", "B", "C"}
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
 }
 
 func TestGTA_Prefix(t *testing.T) {

--- a/gta_test.go
+++ b/gta_test.go
@@ -1366,15 +1366,22 @@ func TestSetRootsOption(t *testing.T) {
 }
 
 // testBaseFileReaderDiffer is a testDiffer that also implements BaseFileReader.
+// baseFiles is keyed by repo-root-relative path; root plays the role of the
+// git toplevel.
 type testBaseFileReaderDiffer struct {
 	testDiffer
+	root      string
 	baseFiles map[string][]byte
 }
 
-func (t *testBaseFileReaderDiffer) ReadBaseFile(relativePath string) ([]byte, error) {
-	data, ok := t.baseFiles[relativePath]
+func (t *testBaseFileReaderDiffer) ReadBaseFile(absPath string) ([]byte, error) {
+	rel, err := filepath.Rel(t.root, absPath)
+	if err != nil {
+		return nil, err
+	}
+	data, ok := t.baseFiles[rel]
 	if !ok {
-		return nil, fmt.Errorf("file %s not found at base", relativePath)
+		return nil, fmt.Errorf("file %s not found at base", rel)
 	}
 	return data, nil
 }
@@ -1396,6 +1403,7 @@ func TestMarkedPackages_GoModChange_PreciseDetection(t *testing.T) {
 				tmpDir: {Exists: true, Files: []string{"go.mod"}},
 			},
 		},
+		root: tmpDir,
 		baseFiles: map[string][]byte{
 			"go.mod": []byte(oldGoMod),
 		},
@@ -1517,6 +1525,7 @@ func TestMarkedPackages_GoSumChange_TransitiveDep(t *testing.T) {
 				tmpDir: {Exists: true, Files: []string{"go.sum"}},
 			},
 		},
+		root: tmpDir,
 		baseFiles: map[string][]byte{
 			"go.sum": []byte(oldGoSum),
 		},

--- a/gta_test.go
+++ b/gta_test.go
@@ -841,6 +841,10 @@ func (w *packageContextTestWrapper) isLocalPackage(importPath string) bool {
 	return w.pc.isLocalPackage(importPath)
 }
 
+func (w *packageContextTestWrapper) LocalImportersOf(modulePaths []string) []string {
+	return w.pc.LocalImportersOf(modulePaths)
+}
+
 func TestChangedPackages_ExternalPackageSkipped(t *testing.T) {
 	// The reverse graph has an external package as a dependent of "C".
 	// PackageFromImport will fail for "external/pkg" since it's not in
@@ -1358,5 +1362,321 @@ func TestSetRootsOption(t *testing.T) {
 	}
 	if len(g.roots) != 1 || g.roots[0] != root {
 		t.Errorf("roots = %v, want [%q]", g.roots, root)
+	}
+}
+
+// testBaseFileReaderDiffer is a testDiffer that also implements BaseFileReader.
+type testBaseFileReaderDiffer struct {
+	testDiffer
+	baseFiles map[string][]byte
+}
+
+func (t *testBaseFileReaderDiffer) ReadBaseFile(relativePath string) ([]byte, error) {
+	data, ok := t.baseFiles[relativePath]
+	if !ok {
+		return nil, fmt.Errorf("file %s not found at base", relativePath)
+	}
+	return data, nil
+}
+
+func TestMarkedPackages_GoModChange_PreciseDetection(t *testing.T) {
+	// When go.mod changes and a BaseFileReader is available, only the local
+	// packages that import the changed dependency should be marked.
+	tmpDir := t.TempDir()
+
+	// Write new go.mod with a version bump for ext/foo
+	newGoMod := "module local\ngo 1.21\nrequire ext/foo v1.1.0\nrequire ext/bar v1.0.0\n"
+	os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(newGoMod), 0644)
+
+	oldGoMod := "module local\ngo 1.21\nrequire ext/foo v1.0.0\nrequire ext/bar v1.0.0\n"
+
+	difr := &testBaseFileReaderDiffer{
+		testDiffer: testDiffer{
+			diff: map[string]Directory{
+				tmpDir: {Exists: true, Files: []string{"go.mod"}},
+			},
+		},
+		baseFiles: map[string][]byte{
+			"go.mod": []byte(oldGoMod),
+		},
+	}
+
+	// Set up packager where local/a imports ext/foo, local/b does not
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{tmpDir: "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"ext/foo/sub": {}},
+			"local/b": {"ext/bar": {}},
+			"local/c": {},
+		},
+		reverse: map[string]map[string]struct{}{
+			"ext/foo/sub": {"local/a": {}},
+			"ext/bar":     {"local/b": {}},
+		},
+		testOnlyReverse:     map[string]map[string]struct{}{},
+		packages:            make(map[string]struct{}),
+		packagesByEmbedFile: make(map[string][]string),
+	}
+
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			tmpDir: "local",
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{tmpDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// Only local/a should be marked (it imports ext/foo)
+	// local/b and local/c should NOT be marked
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	want := []string{"local/a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+func TestMarkedPackages_GoModChange_FallbackToNuclear(t *testing.T) {
+	// When the differ does NOT implement BaseFileReader and no base options
+	// are set, fall back to the nuclear option (mark all packages).
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module local\ngo 1.21\n"), 0644)
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			tmpDir: {Exists: true, Files: []string{"go.mod"}},
+		},
+	}
+
+	graph := &Graph{
+		graph: map[string]map[string]bool{
+			"A": {"B": true},
+		},
+	}
+
+	pkgr := &testPackager{
+		dirs2Imports: map[string]string{
+			tmpDir: "local",
+			"dirA": "A",
+			"dirB": "B",
+		},
+		graph: graph,
+		errs:  make(map[string]error),
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(pkgr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{tmpDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// With nuclear option, A and B should be marked (from graph)
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	// Nuclear marks everything in the graph
+	if len(got) < 2 {
+		t.Errorf("expected nuclear option to mark multiple packages, got %v", got)
+	}
+}
+
+func TestMarkedPackages_GoSumChange_TransitiveDep(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Only go.sum changed (go.mod unchanged)
+	newGoSum := "ext/foo v1.1.0 h1:newhash\next/foo v1.1.0/go.mod h1:modhash\n"
+	os.WriteFile(filepath.Join(tmpDir, "go.sum"), []byte(newGoSum), 0644)
+
+	oldGoSum := "ext/foo v1.0.0 h1:oldhash\next/foo v1.0.0/go.mod h1:modhash\n"
+
+	difr := &testBaseFileReaderDiffer{
+		testDiffer: testDiffer{
+			diff: map[string]Directory{
+				tmpDir: {Exists: true, Files: []string{"go.sum"}},
+			},
+		},
+		baseFiles: map[string][]byte{
+			"go.sum": []byte(oldGoSum),
+		},
+	}
+
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{tmpDir: "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"ext/foo": {}},
+			"local/b": {"ext/bar": {}},
+		},
+		reverse: map[string]map[string]struct{}{
+			"ext/foo": {"local/a": {}},
+			"ext/bar": {"local/b": {}},
+		},
+		testOnlyReverse:     map[string]map[string]struct{}{},
+		packages:            make(map[string]struct{}),
+		packagesByEmbedFile: make(map[string][]string),
+	}
+
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			tmpDir: "local",
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{tmpDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	// Only local/a should be marked (imports ext/foo which changed in go.sum)
+	want := []string{"local/a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+func TestMarkedPackages_GoWorkChange_StillNuclear(t *testing.T) {
+	// go.work changes should still use the nuclear option
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			"dir": {Exists: true, Files: []string{"go.work"}},
+		},
+	}
+
+	graph := &Graph{
+		graph: map[string]map[string]bool{
+			"A": {"B": true},
+			"B": {},
+		},
+	}
+
+	pkgr := &testPackager{
+		dirs2Imports: map[string]string{
+			"dirA": "A",
+			"dirB": "B",
+		},
+		graph: graph,
+		errs:  make(map[string]error),
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(pkgr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// go.work change should mark all packages in the graph (nuclear)
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	want := []string{"A", "B"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
+func TestMarkedPackages_BaseGoModOption(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write old and new go.mod files
+	oldGoMod := "module local\ngo 1.21\nrequire ext/foo v1.0.0\nrequire ext/bar v1.0.0\n"
+	newGoMod := "module local\ngo 1.21\nrequire ext/foo v1.1.0\nrequire ext/bar v1.0.0\n"
+
+	oldGoModPath := filepath.Join(tmpDir, "old_go.mod")
+	os.WriteFile(oldGoModPath, []byte(oldGoMod), 0644)
+
+	modDir := filepath.Join(tmpDir, "module")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "go.mod"), []byte(newGoMod), 0644)
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			modDir: {Exists: true, Files: []string{"go.mod"}},
+		},
+	}
+
+	pc := &packageContext{
+		modulesNamesByDir: map[string]string{modDir: "local"},
+		forward: map[string]map[string]struct{}{
+			"local/a": {"ext/foo": {}},
+			"local/b": {"ext/bar": {}},
+		},
+		reverse: map[string]map[string]struct{}{
+			"ext/foo": {"local/a": {}},
+			"ext/bar": {"local/b": {}},
+		},
+		testOnlyReverse:     map[string]map[string]struct{}{},
+		packages:            make(map[string]struct{}),
+		packagesByEmbedFile: make(map[string][]string),
+	}
+
+	wrapper := &packageContextTestWrapper{
+		pc: pc,
+		dirs2Imports: map[string]string{
+			modDir: "local",
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(wrapper), SetBaseGoMod(oldGoModPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gta.roots = []string{modDir}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+
+	// Only local/a should be marked (imports ext/foo which changed)
+	want := []string{"local/a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -51,3 +51,13 @@ func SetIncludeTransitiveTestDeps(include bool) Option {
 		return nil
 	}
 }
+
+// SetDisableWorkspace disables Go workspace (go.work) detection. When true,
+// GTA operates in single-module mode even if a go.work file is present.
+// This is equivalent to setting the GOWORK=off environment variable.
+func SetDisableWorkspace(disable bool) Option {
+	return func(g *GTA) error {
+		g.disableWorkspace = disable
+		return nil
+	}
+}

--- a/options.go
+++ b/options.go
@@ -61,3 +61,21 @@ func SetDisableWorkspace(disable bool) Option {
 		return nil
 	}
 }
+
+// SetBaseGoMod provides old go.mod content for dependency diff analysis
+// when using a file differ (no git access).
+func SetBaseGoMod(path string) Option {
+	return func(g *GTA) error {
+		g.baseGoMod = path
+		return nil
+	}
+}
+
+// SetBaseGoSum provides old go.sum content for dependency diff analysis
+// when using a file differ (no git access).
+func SetBaseGoSum(path string) Option {
+	return func(g *GTA) error {
+		g.baseGoSum = path
+		return nil
+	}
+}

--- a/options.go
+++ b/options.go
@@ -60,3 +60,21 @@ func SetRoots(roots ...string) Option {
 		return nil
 	}
 }
+
+// SetBaseGoMod provides old go.mod content for dependency diff analysis
+// when using a file differ (no git access).
+func SetBaseGoMod(path string) Option {
+	return func(g *GTA) error {
+		g.baseGoMod = path
+		return nil
+	}
+}
+
+// SetBaseGoSum provides old go.sum content for dependency diff analysis
+// when using a file differ (no git access).
+func SetBaseGoSum(path string) Option {
+	return func(g *GTA) error {
+		g.baseGoSum = path
+		return nil
+	}
+}

--- a/packager.go
+++ b/packager.go
@@ -420,6 +420,43 @@ func normalizeImportPath(pkg *packages.Package) string {
 	return importPath
 }
 
+// isLocalPackage returns true if the import path belongs to a main
+// (local/workspace) module.
+func (p *packageContext) isLocalPackage(importPath string) bool {
+	for _, modPath := range p.modulesNamesByDir {
+		if importPath == modPath || strings.HasPrefix(importPath, modPath+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// LocalImportersOf returns the import paths of local packages that
+// import any package from the given module paths.
+func (p *packageContext) LocalImportersOf(modulePaths []string) []string {
+	moduleSet := make(map[string]struct{}, len(modulePaths))
+	for _, mp := range modulePaths {
+		moduleSet[mp] = struct{}{}
+	}
+
+	var importers []string
+	for pkgPath, imports := range p.forward {
+		if !p.isLocalPackage(pkgPath) {
+			continue
+		}
+		for dep := range imports {
+			for mp := range moduleSet {
+				if dep == mp || strings.HasPrefix(dep, mp+"/") {
+					importers = append(importers, pkgPath)
+					goto nextPkg
+				}
+			}
+		}
+	nextPkg:
+	}
+	return importers
+}
+
 func stripVendor(importPath string) string {
 	if os.Getenv("GO111MODULE") == "off" {
 		return importPath

--- a/packager.go
+++ b/packager.go
@@ -60,9 +60,9 @@ type Packager interface {
 	EmbeddedBy(string) []string
 }
 
-func NewPackager(patterns, tags []string) Packager {
+func NewPackager(patterns, tags []string, disableWorkspace bool) Packager {
 	build.Default.BuildTags = tags
-	return newPackager(newLoadConfig(tags), build.Default, patterns)
+	return newPackager(newLoadConfig(tags, disableWorkspace), build.Default, patterns)
 }
 
 func newPackager(cfg *packages.Config, ctx build.Context, patterns []string) Packager {
@@ -81,8 +81,8 @@ func newPackager(cfg *packages.Config, ctx build.Context, patterns []string) Pac
 
 // newLoadConfig returns a *packages.Config suitable for use by packages.Load.
 // The constructor here is mostly useful for tests.
-func newLoadConfig(tags []string) *packages.Config {
-	return &packages.Config{
+func newLoadConfig(tags []string, disableWorkspace bool) *packages.Config {
+	cfg := &packages.Config{
 		Mode: packages.NeedName |
 			packages.NeedFiles |
 			packages.NeedEmbedFiles |
@@ -95,6 +95,10 @@ func newLoadConfig(tags []string) *packages.Config {
 		},
 		Tests: true,
 	}
+	if disableWorkspace {
+		cfg.Env = append(os.Environ(), "GOWORK=off")
+	}
+	return cfg
 }
 
 // packageContext implements the Packager interface.

--- a/packager.go
+++ b/packager.go
@@ -309,6 +309,12 @@ func dependencyGraph(cfg *packages.Config, patterns []string) (moduleNamesByDir 
 
 		seen[pkg.ID] = struct{}{}
 
+		// Skip packages with load errors (e.g., unresolvable external deps).
+		// The module info has already been recorded above.
+		if len(pkg.Errors) > 0 {
+			return
+		}
+
 		// Ignore packages that do not have any Go files that satisfy the build
 		// constraints.
 		if len(pkg.GoFiles) == 0 {

--- a/packager.go
+++ b/packager.go
@@ -427,8 +427,12 @@ func normalizeImportPath(pkg *packages.Package) string {
 }
 
 // isLocalPackage returns true if the import path belongs to a main
-// (local/workspace) module.
+// (local/workspace) module. In GOPATH mode (no modules), all packages
+// are considered local.
 func (p *packageContext) isLocalPackage(importPath string) bool {
+	if len(p.modulesNamesByDir) == 0 {
+		return true
+	}
 	for _, modPath := range p.modulesNamesByDir {
 		if importPath == modPath || strings.HasPrefix(importPath, modPath+"/") {
 			return true

--- a/packager.go
+++ b/packager.go
@@ -305,6 +305,12 @@ func dependencyGraph(cfg *packages.Config, patterns []string) (moduleNamesByDir 
 
 		seen[pkg.ID] = struct{}{}
 
+		// Skip packages with load errors (e.g., unresolvable external deps).
+		// The module info has already been recorded above.
+		if len(pkg.Errors) > 0 {
+			return
+		}
+
 		// Ignore packages that do not have any Go files that satisfy the build
 		// constraints.
 		if len(pkg.GoFiles) == 0 {

--- a/packager.go
+++ b/packager.go
@@ -217,6 +217,8 @@ func resolveLocal(pkg *Package, dir string, modulesByDir map[string]string) {
 		return
 	}
 
+	dir = canonicalDir(dir) // normalize before comparing to canonical module dirs
+
 	importPath := pkg.ImportPath
 
 	var mruPrefix string
@@ -300,7 +302,7 @@ func dependencyGraph(cfg *packages.Config, patterns []string) (moduleNamesByDir 
 		}
 
 		if pkg.Module != nil && pkg.Module.Main {
-			moduleNamesByDir[pkg.Module.Dir] = pkg.Module.Path
+			moduleNamesByDir[canonicalDir(pkg.Module.Dir)] = pkg.Module.Path
 		}
 
 		seen[pkg.ID] = struct{}{}
@@ -475,4 +477,28 @@ func stripVendor(importPath string) string {
 	}
 
 	return importPath
+}
+
+// canonicalDir resolves symlinks in dir to match the form packages.Load
+// reports for Module.Dir (the go tool resolves symlinks via EvalSymlinks).
+// Equality/prefix comparisons against module dirs are otherwise fragile on
+// systems where the repo path differs from its resolved form (e.g. macOS
+// /tmp -> /private/tmp, container bind mounts, automounts).
+//
+// If dir does not exist (e.g. a deleted package directory), the deepest
+// existing ancestor is resolved and the remainder re-appended, so prefix and
+// equality comparisons still line up with resolved module dirs.
+func canonicalDir(dir string) string {
+	if dir == "" {
+		return dir
+	}
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	parent := filepath.Dir(dir)
+	if parent == dir {
+		// reached the filesystem root; cannot resolve further
+		return dir
+	}
+	return filepath.Join(canonicalDir(parent), filepath.Base(dir))
 }

--- a/packager.go
+++ b/packager.go
@@ -416,6 +416,43 @@ func normalizeImportPath(pkg *packages.Package) string {
 	return importPath
 }
 
+// isLocalPackage returns true if the import path belongs to a main
+// (local/workspace) module.
+func (p *packageContext) isLocalPackage(importPath string) bool {
+	for _, modPath := range p.modulesNamesByDir {
+		if importPath == modPath || strings.HasPrefix(importPath, modPath+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// LocalImportersOf returns the import paths of local packages that
+// import any package from the given module paths.
+func (p *packageContext) LocalImportersOf(modulePaths []string) []string {
+	moduleSet := make(map[string]struct{}, len(modulePaths))
+	for _, mp := range modulePaths {
+		moduleSet[mp] = struct{}{}
+	}
+
+	var importers []string
+	for pkgPath, imports := range p.forward {
+		if !p.isLocalPackage(pkgPath) {
+			continue
+		}
+		for dep := range imports {
+			for mp := range moduleSet {
+				if dep == mp || strings.HasPrefix(dep, mp+"/") {
+					importers = append(importers, pkgPath)
+					goto nextPkg
+				}
+			}
+		}
+	nextPkg:
+	}
+	return importers
+}
+
 func stripVendor(importPath string) string {
 	if os.Getenv("GO111MODULE") == "off" {
 		return importPath

--- a/packager.go
+++ b/packager.go
@@ -423,8 +423,12 @@ func normalizeImportPath(pkg *packages.Package) string {
 }
 
 // isLocalPackage returns true if the import path belongs to a main
-// (local/workspace) module.
+// (local/workspace) module. In GOPATH mode (no modules), all packages
+// are considered local.
 func (p *packageContext) isLocalPackage(importPath string) bool {
+	if len(p.modulesNamesByDir) == 0 {
+		return true
+	}
 	for _, modPath := range p.modulesNamesByDir {
 		if importPath == modPath || strings.HasPrefix(importPath, modPath+"/") {
 			return true

--- a/packager_test.go
+++ b/packager_test.go
@@ -58,10 +58,10 @@ func TestIsLocalPackage(t *testing.T) {
 			want:              true,
 		},
 		{
-			name:              "empty modulesNamesByDir",
+			name:              "empty modulesNamesByDir (GOPATH mode) treats all as local",
 			modulesNamesByDir: map[string]string{},
 			importPath:        "mymod/pkg",
-			want:              false,
+			want:              true,
 		},
 	}
 

--- a/packager_test.go
+++ b/packager_test.go
@@ -78,6 +78,56 @@ func TestIsLocalPackage(t *testing.T) {
 	}
 }
 
+func TestAddPackage_SkipsErroredPackages(t *testing.T) {
+	// Verify that packages with load errors are not added to the
+	// forward/reverse dependency graphs. We test this indirectly by
+	// constructing a GTA with a testPackager whose graph excludes the errored
+	// package. The key assertion is that ChangedPackages succeeds and
+	// does not include the errored package.
+	graph := &Graph{
+		graph: map[string]map[string]bool{
+			"B": {"A": true},
+		},
+	}
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			"dirB": {Exists: true, Files: []string{"b.go"}},
+		},
+	}
+
+	pkgr := &testPackager{
+		dirs2Imports: map[string]string{
+			"dirA": "A",
+			"dirB": "B",
+		},
+		graph: graph,
+		errs:  make(map[string]error),
+	}
+
+	gta, err := New(SetDiffer(difr), SetPackager(pkgr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that A and B are in AllChanges (errored packages excluded
+	// from graph wouldn't appear here).
+	want := []string{"A", "B"}
+	var got []string
+	for _, p := range pkgs.AllChanges {
+		got = append(got, p.ImportPath)
+	}
+	sort.Strings(got)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("(-want, +got)\n%s", diff)
+	}
+}
+
 func TestLocalImportersOf(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/packager_test.go
+++ b/packager_test.go
@@ -1,10 +1,152 @@
 package gta
 
-import "testing"
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestPackageContextImplementsPackager(t *testing.T) {
 	var sut interface{} = new(packageContext)
 	if _, ok := sut.(Packager); !ok {
 		t.Error("expected to implement Packager")
+	}
+}
+
+func TestIsLocalPackage(t *testing.T) {
+	tests := []struct {
+		name              string
+		modulesNamesByDir map[string]string
+		importPath        string
+		want              bool
+	}{
+		{
+			name:              "local exact match",
+			modulesNamesByDir: map[string]string{"/repo": "mymod"},
+			importPath:        "mymod",
+			want:              true,
+		},
+		{
+			name:              "local subpackage",
+			modulesNamesByDir: map[string]string{"/repo": "mymod"},
+			importPath:        "mymod/pkg/foo",
+			want:              true,
+		},
+		{
+			name:              "external package",
+			modulesNamesByDir: map[string]string{"/repo": "mymod"},
+			importPath:        "golang.org/x/text",
+			want:              false,
+		},
+		{
+			name:              "stdlib package",
+			modulesNamesByDir: map[string]string{"/repo": "mymod"},
+			importPath:        "fmt",
+			want:              false,
+		},
+		{
+			name:              "similar prefix no match",
+			modulesNamesByDir: map[string]string{"/repo": "mymod"},
+			importPath:        "mymod2/foo",
+			want:              false,
+		},
+		{
+			name:              "workspace multi-module",
+			modulesNamesByDir: map[string]string{"/ws/a": "ws/a", "/ws/b": "ws/b"},
+			importPath:        "ws/a/pkg",
+			want:              true,
+		},
+		{
+			name:              "empty modulesNamesByDir",
+			modulesNamesByDir: map[string]string{},
+			importPath:        "mymod/pkg",
+			want:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &packageContext{
+				modulesNamesByDir: tt.modulesNamesByDir,
+			}
+			got := p.isLocalPackage(tt.importPath)
+			if got != tt.want {
+				t.Errorf("isLocalPackage(%q) = %v, want %v", tt.importPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalImportersOf(t *testing.T) {
+	tests := []struct {
+		name              string
+		modulesNamesByDir map[string]string
+		forward           map[string]map[string]struct{}
+		changedModules    []string
+		want              []string
+	}{
+		{
+			name:              "local package imports subpackage of changed module",
+			modulesNamesByDir: map[string]string{"/repo": "local"},
+			forward: map[string]map[string]struct{}{
+				"local/a": {"ext/foo/sub": {}},
+			},
+			changedModules: []string{"ext/foo"},
+			want:           []string{"local/a"},
+		},
+		{
+			name:              "multiple local packages import changed module",
+			modulesNamesByDir: map[string]string{"/repo": "local"},
+			forward: map[string]map[string]struct{}{
+				"local/a": {"ext/foo": {}},
+				"local/b": {"ext/foo": {}},
+			},
+			changedModules: []string{"ext/foo"},
+			want:           []string{"local/a", "local/b"},
+		},
+		{
+			name:              "no local package imports changed module",
+			modulesNamesByDir: map[string]string{"/repo": "local"},
+			forward: map[string]map[string]struct{}{
+				"local/a": {"ext/bar": {}},
+			},
+			changedModules: []string{"ext/foo"},
+			want:           nil,
+		},
+		{
+			name:              "external package importing changed module is skipped",
+			modulesNamesByDir: map[string]string{"/repo": "local"},
+			forward: map[string]map[string]struct{}{
+				"ext/baz": {"ext/foo": {}},
+			},
+			changedModules: []string{"ext/foo"},
+			want:           nil,
+		},
+		{
+			name:              "multiple changed modules",
+			modulesNamesByDir: map[string]string{"/repo": "local"},
+			forward: map[string]map[string]struct{}{
+				"local/a": {"ext/foo": {}},
+				"local/b": {"ext/bar": {}},
+			},
+			changedModules: []string{"ext/foo", "ext/bar"},
+			want:           []string{"local/a", "local/b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &packageContext{
+				modulesNamesByDir: tt.modulesNamesByDir,
+				forward:           tt.forward,
+			}
+			got := p.LocalImportersOf(tt.changedModules)
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("LocalImportersOf() (-want, +got)\n%s", diff)
+			}
+		})
 	}
 }

--- a/testdata/workspacegomod/depsrc/dep.go
+++ b/testdata/workspacegomod/depsrc/dep.go
@@ -1,0 +1,7 @@
+package dep
+
+// Answer returns a constant. It exists so workspace modules have a real
+// symbol to import.
+func Answer() int {
+	return 42
+}

--- a/testdata/workspacegomod/depsrc/go.mod
+++ b/testdata/workspacegomod/depsrc/go.mod
@@ -1,0 +1,3 @@
+module example.test/dep
+
+go 1.21

--- a/testdata/workspacegomod/go.mod
+++ b/testdata/workspacegomod/go.mod
@@ -1,0 +1,5 @@
+module workspace.gomod/root
+
+go 1.21
+
+require example.test/dep v1.1.0

--- a/testdata/workspacegomod/go.work
+++ b/testdata/workspacegomod/go.work
@@ -1,0 +1,13 @@
+go 1.21
+
+use (
+	./modA
+	./modB
+)
+
+// Replace the "external" dependency with a local directory so that
+// packages.Load resolves it offline. Placing the replace here (rather than
+// in the module go.mod files) keeps the go.mod files minimal: diffGoMod only
+// inspects require/replace directives of go.mod files, and the scenario under
+// test depends on the require directives alone.
+replace example.test/dep => ./depsrc

--- a/testdata/workspacegomod/modA/a.go
+++ b/testdata/workspacegomod/modA/a.go
@@ -1,0 +1,7 @@
+package a
+
+// A is a trivial function in a module that does not import the external
+// dependency.
+func A() int {
+	return 1
+}

--- a/testdata/workspacegomod/modA/go.mod
+++ b/testdata/workspacegomod/modA/go.mod
@@ -1,0 +1,3 @@
+module workspace.gomod/modA
+
+go 1.21

--- a/testdata/workspacegomod/modB/b.go
+++ b/testdata/workspacegomod/modB/b.go
@@ -1,0 +1,9 @@
+package b
+
+import "example.test/dep"
+
+// B depends on the external dependency, so a version change of
+// example.test/dep in modB/go.mod must mark this package.
+func B() int {
+	return dep.Answer()
+}

--- a/testdata/workspacegomod/modB/go.mod
+++ b/testdata/workspacegomod/modB/go.mod
@@ -1,0 +1,5 @@
+module workspace.gomod/modB
+
+go 1.21
+
+require example.test/dep v1.1.0

--- a/testdata/workspacetest/go.work
+++ b/testdata/workspacetest/go.work
@@ -1,0 +1,7 @@
+go 1.25
+
+use (
+	./modA
+	./modB
+	./modC
+)

--- a/testdata/workspacetest/modA/go.mod
+++ b/testdata/workspacetest/modA/go.mod
@@ -1,0 +1,5 @@
+module workspace.test/modA
+
+go 1.25
+
+require workspace.test/modB v0.0.0

--- a/testdata/workspacetest/modA/pkg/a.go
+++ b/testdata/workspacetest/modA/pkg/a.go
@@ -1,0 +1,5 @@
+package pkg
+
+import "workspace.test/modB/pkg"
+
+func UsesB() string { return pkg.Hello() }

--- a/testdata/workspacetest/modB/go.mod
+++ b/testdata/workspacetest/modB/go.mod
@@ -1,0 +1,3 @@
+module workspace.test/modB
+
+go 1.25

--- a/testdata/workspacetest/modB/internal/util.go
+++ b/testdata/workspacetest/modB/internal/util.go
@@ -1,0 +1,3 @@
+package internal
+
+func Format(s string) string { return s }

--- a/testdata/workspacetest/modB/pkg/b.go
+++ b/testdata/workspacetest/modB/pkg/b.go
@@ -1,0 +1,3 @@
+package pkg
+
+func Hello() string { return "hello" }

--- a/testdata/workspacetest/modC/go.mod
+++ b/testdata/workspacetest/modC/go.mod
@@ -1,0 +1,5 @@
+module workspace.test/modC
+
+go 1.25
+
+require workspace.test/modA v0.0.0

--- a/testdata/workspacetest/modC/pkg/c.go
+++ b/testdata/workspacetest/modC/pkg/c.go
@@ -1,0 +1,5 @@
+package pkg
+
+import "workspace.test/modA/pkg"
+
+func TransitiveUse() string { return pkg.UsesB() }

--- a/testdata/workspacetest/modD/go.mod
+++ b/testdata/workspacetest/modD/go.mod
@@ -1,0 +1,3 @@
+module workspace.test/modD
+
+go 1.25

--- a/testdata/workspacetest/modD/pkg/d.go
+++ b/testdata/workspacetest/modD/pkg/d.go
@@ -1,0 +1,3 @@
+package pkg
+
+func Standalone() string { return "standalone" }

--- a/workspace_gomod_test.go
+++ b/workspace_gomod_test.go
@@ -1,0 +1,165 @@
+package gta
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// testBaseReaderDiffer is a Differ that also implements BaseFileReader,
+// simulating the git differ's ReadBaseFile. The real implementation runs
+//
+//	git -C <repo toplevel> show <baseRef>:<relativePath>
+//
+// (see (*git).readBaseFile in differ.go), so the relativePath it receives is
+// always interpreted relative to the git repository root. baseFiles is
+// therefore keyed by repo-root-relative paths. requested records every path
+// the code under test asks for, so a failure can show *which* file was
+// consulted, not just that detection failed.
+type testBaseReaderDiffer struct {
+	testDiffer
+	baseFiles map[string][]byte
+	requested []string
+}
+
+var _ BaseFileReader = &testBaseReaderDiffer{}
+
+func (d *testBaseReaderDiffer) ReadBaseFile(relativePath string) ([]byte, error) {
+	d.requested = append(d.requested, relativePath)
+	b, ok := d.baseFiles[relativePath]
+	if !ok {
+		return nil, fmt.Errorf("path %q does not exist at base ref", relativePath)
+	}
+	return b, nil
+}
+
+// TestChangedPackages_WorkspaceGoModPreciseDiff demonstrates a false negative
+// in the precise go.mod diff analysis when running in Go workspace mode.
+//
+// Scenario (fixture: testdata/workspacegomod):
+//
+//	<repo root>            <- git repository toplevel
+//	├── go.work            uses ./modA and ./modB (root module NOT in workspace)
+//	├── go.mod             root tooling module, requires example.test/dep v1.1.0
+//	├── modA/              workspace module, no external deps
+//	├── modB/              workspace module, requires example.test/dep
+//	│   ├── go.mod         base ref: v1.0.0 -> HEAD: v1.1.0 (the only change)
+//	│   └── b.go           imports example.test/dep
+//	└── depsrc/            local source of example.test/dep (via go.work replace)
+//
+// The change between the base ref and HEAD is a single dependency bump in
+// modB/go.mod: example.test/dep v1.0.0 -> v1.1.0. Because modB's package
+// imports example.test/dep, GTA must mark workspace.gomod/modB as changed.
+//
+// Why the current code misses it:
+//
+//  1. In workspace mode, workspaceroots() sets g.roots to the workspace
+//     module directories taken from the go.work use directives:
+//     [<root>/modA, <root>/modB]. The repository root itself is not in
+//     g.roots unless go.work happens to contain "use ." ordered before the
+//     module that changed.
+//
+//  2. markedPackages() sees modB/go.mod in the diff and calls
+//     relativeModFilePath(<root>/modB, g.roots, "go.mod") to compute the
+//     path to pass to BaseFileReader.ReadBaseFile. The first root that
+//     prefix-matches <root>/modB is <root>/modB itself, so the function
+//     returns "go.mod" -- a path relative to the *module* directory.
+//
+//  3. ReadBaseFile resolves paths relative to the *git repository root*
+//     (git show <base>:go.mod). Since the repo root contains its own go.mod
+//     (the tooling module), the read SUCCEEDS but returns the wrong file:
+//     the root go.mod instead of modB/go.mod.
+//
+//  4. diffGoMod then compares the base-ref ROOT go.mod against the new
+//     modB/go.mod. diffGoMod only inspects require/replace directives, so
+//     the differing module lines are invisible to it. The root module
+//     already requires example.test/dep v1.1.0 -- the very version modB just
+//     bumped to, a routine "catch up to the version the rest of the repo
+//     uses" situation in a monorepo. The requires match, the diff comes back
+//     empty, and preciseDetection is reported true with zero changed module
+//     paths.
+//
+//  5. With preciseDetection == true and no changed module paths, neither the
+//     precise branch nor the nuclear fallback marks anything. modB's diff
+//     contains no .go files, so the directory is then skipped entirely.
+//     Result: ChangedPackages reports nothing -- a false negative for a
+//     dependency change that affects workspace.gomod/modB.
+//
+// The test asserts the CORRECT behavior (workspace.gomod/modB is reported),
+// so it fails on the current code, demonstrating the bug. Note the exact
+// equality assertion also rules out passing via the nuclear fallback, which
+// would mark modA as well.
+func TestChangedPackages_WorkspaceGoModPreciseDiff(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacegomod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// The on-disk fixture represents the NEW state (modB requires
+	// example.test/dep v1.1.0). The differ below serves the base-ref state:
+	// modB/go.mod still at v1.0.0, and the root go.mod unchanged between the
+	// base ref and HEAD.
+	rootGoModAtBase, err := os.ReadFile(filepath.Join(wsDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modBGoModAtBase := []byte(`module workspace.gomod/modB
+
+go 1.21
+
+require example.test/dep v1.0.0
+`)
+
+	modBDir := filepath.Join(wsDir, "modB")
+	difr := &testBaseReaderDiffer{
+		testDiffer: testDiffer{
+			diff: map[string]Directory{
+				// The only change between base and HEAD: modB/go.mod.
+				modBDir: {Exists: true, Files: []string{"go.mod"}},
+			},
+		},
+		baseFiles: map[string][]byte{
+			// Keyed by git-repo-root-relative path, as git show would see it.
+			"go.mod":      rootGoModAtBase,
+			"modB/go.mod": modBGoModAtBase,
+		},
+	}
+
+	gta, err := New(SetDiffer(difr))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+
+	// modB's package imports example.test/dep, whose required version
+	// changed, so it -- and only it -- must be reported.
+	wantPaths := []string{"workspace.gomod/modB"}
+
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s", diff)
+		t.Logf("base files consulted via ReadBaseFile: %q", difr.requested)
+		t.Logf("(a request for %q instead of %q means the root go.mod was diffed against modB's new go.mod)", "go.mod", "modB/go.mod")
+	}
+}

--- a/workspace_gomod_test.go
+++ b/workspace_gomod_test.go
@@ -10,34 +10,39 @@ import (
 )
 
 // testBaseReaderDiffer is a Differ that also implements BaseFileReader,
-// simulating the git differ's ReadBaseFile. The real implementation runs
-//
-//	git -C <repo toplevel> show <baseRef>:<relativePath>
-//
-// (see (*git).readBaseFile in differ.go), so the relativePath it receives is
-// always interpreted relative to the git repository root. baseFiles is
-// therefore keyed by repo-root-relative paths. requested records every path
-// the code under test asks for, so a failure can show *which* file was
-// consulted, not just that detection failed.
+// simulating the git differ's ReadBaseFile. The real implementation receives
+// an absolute path and resolves it against the git repository toplevel
+// (see (*git).readBaseFile in differ.go). root plays the role of the git
+// toplevel; baseFiles is keyed by repo-root-relative paths. requested records
+// every absolute path the code under test passes in, so a failure can show
+// *which* file was consulted, not just that detection failed.
 type testBaseReaderDiffer struct {
 	testDiffer
+	root      string
 	baseFiles map[string][]byte
 	requested []string
 }
 
 var _ BaseFileReader = &testBaseReaderDiffer{}
 
-func (d *testBaseReaderDiffer) ReadBaseFile(relativePath string) ([]byte, error) {
-	d.requested = append(d.requested, relativePath)
-	b, ok := d.baseFiles[relativePath]
+func (d *testBaseReaderDiffer) ReadBaseFile(absPath string) ([]byte, error) {
+	d.requested = append(d.requested, absPath)
+	rel, err := filepath.Rel(d.root, absPath)
+	if err != nil {
+		return nil, err
+	}
+	b, ok := d.baseFiles[rel]
 	if !ok {
-		return nil, fmt.Errorf("path %q does not exist at base ref", relativePath)
+		return nil, fmt.Errorf("path %q does not exist at base ref", rel)
 	}
 	return b, nil
 }
 
-// TestChangedPackages_WorkspaceGoModPreciseDiff demonstrates a false negative
-// in the precise go.mod diff analysis when running in Go workspace mode.
+// TestChangedPackages_WorkspaceGoModPreciseDiff is a regression test for the
+// path-resolution contract: ReadBaseFile receives absolute paths and the differ
+// resolves them against the repository root; under the fork's multi-root
+// semantics this scenario produced a false negative (root go.mod silently
+// diffed against modB's new go.mod).
 //
 // Scenario (fixture: testdata/workspacegomod):
 //
@@ -54,44 +59,38 @@ func (d *testBaseReaderDiffer) ReadBaseFile(relativePath string) ([]byte, error)
 // modB/go.mod: example.test/dep v1.0.0 -> v1.1.0. Because modB's package
 // imports example.test/dep, GTA must mark workspace.gomod/modB as changed.
 //
-// Why the current code misses it:
+// Historical 5-step failure mechanism (before path-resolution was moved into
+// the differ):
 //
-//  1. In workspace mode, workspaceroots() sets g.roots to the workspace
-//     module directories taken from the go.work use directives:
-//     [<root>/modA, <root>/modB]. The repository root itself is not in
-//     g.roots unless go.work happens to contain "use ." ordered before the
-//     module that changed.
+//  1. In workspace mode, workspaceroots() set g.roots to the workspace module
+//     directories taken from go.work use directives: [<root>/modA, <root>/modB].
+//     The repository root itself was not in g.roots unless go.work happened to
+//     contain "use ." ordered before the module that changed.
 //
-//  2. markedPackages() sees modB/go.mod in the diff and calls
-//     relativeModFilePath(<root>/modB, g.roots, "go.mod") to compute the
-//     path to pass to BaseFileReader.ReadBaseFile. The first root that
-//     prefix-matches <root>/modB is <root>/modB itself, so the function
-//     returns "go.mod" -- a path relative to the *module* directory.
+//  2. markedPackages() saw modB/go.mod in the diff and called
+//     relativeModFilePath(<root>/modB, g.roots, "go.mod") to compute the path
+//     to pass to BaseFileReader.ReadBaseFile. The first root that
+//     prefix-matched <root>/modB was <root>/modB itself, so the function
+//     returned "go.mod" -- a path relative to the *module* directory.
 //
-//  3. ReadBaseFile resolves paths relative to the *git repository root*
-//     (git show <base>:go.mod). Since the repo root contains its own go.mod
-//     (the tooling module), the read SUCCEEDS but returns the wrong file:
+//  3. ReadBaseFile resolved paths relative to the *git repository root*
+//     (git show <base>:go.mod). Since the repo root contained its own go.mod
+//     (the tooling module), the read SUCCEEDED but returned the wrong file:
 //     the root go.mod instead of modB/go.mod.
 //
-//  4. diffGoMod then compares the base-ref ROOT go.mod against the new
-//     modB/go.mod. diffGoMod only inspects require/replace directives, so
-//     the differing module lines are invisible to it. The root module
-//     already requires example.test/dep v1.1.0 -- the very version modB just
-//     bumped to, a routine "catch up to the version the rest of the repo
-//     uses" situation in a monorepo. The requires match, the diff comes back
-//     empty, and preciseDetection is reported true with zero changed module
-//     paths.
+//  4. diffGoMod compared the base-ref ROOT go.mod against the new modB/go.mod.
+//     diffGoMod only inspects require/replace directives, so the differing
+//     module lines were invisible to it. The root module already required
+//     example.test/dep v1.1.0 -- the very version modB just bumped to, a
+//     routine "catch up to the version the rest of the repo uses" situation in
+//     a monorepo. The requires matched, the diff came back empty, and
+//     preciseDetection was reported true with zero changed module paths.
 //
 //  5. With preciseDetection == true and no changed module paths, neither the
-//     precise branch nor the nuclear fallback marks anything. modB's diff
-//     contains no .go files, so the directory is then skipped entirely.
-//     Result: ChangedPackages reports nothing -- a false negative for a
-//     dependency change that affects workspace.gomod/modB.
-//
-// The test asserts the CORRECT behavior (workspace.gomod/modB is reported),
-// so it fails on the current code, demonstrating the bug. Note the exact
-// equality assertion also rules out passing via the nuclear fallback, which
-// would mark modA as well.
+//     precise branch nor the nuclear fallback marked anything. modB's diff
+//     contained no .go files, so the directory was then skipped entirely.
+//     Result: ChangedPackages reported nothing -- a false negative for a
+//     dependency change that affected workspace.gomod/modB.
 func TestChangedPackages_WorkspaceGoModPreciseDiff(t *testing.T) {
 	origDir, err := os.Getwd()
 	if err != nil {
@@ -131,6 +130,7 @@ require example.test/dep v1.0.0
 				modBDir: {Exists: true, Files: []string{"go.mod"}},
 			},
 		},
+		root: wsDir,
 		baseFiles: map[string][]byte{
 			// Keyed by git-repo-root-relative path, as git show would see it.
 			"go.mod":      rootGoModAtBase,

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -1,0 +1,340 @@
+package gta
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWorkspaceRoots(t *testing.T) {
+	// Save and restore the working directory.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Change to workspace directory so go env GOWORK finds the go.work file.
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	roots, err := workspaceroots()
+	if err != nil {
+		t.Fatalf("workspaceroots() error: %v", err)
+	}
+
+	if roots == nil {
+		t.Fatal("workspaceroots() returned nil; expected workspace roots")
+	}
+
+	// We expect 3 roots: modA, modB, modC (modD is not in go.work).
+	if len(roots) != 3 {
+		t.Fatalf("expected 3 roots, got %d: %v", len(roots), roots)
+	}
+
+	sort.Strings(roots)
+	for i, want := range []string{"modA", "modB", "modC"} {
+		wantSuffix := filepath.Join("workspacetest", want)
+		if !containsSuffix(roots[i], wantSuffix) {
+			t.Errorf("roots[%d] = %q; want suffix %q", i, roots[i], wantSuffix)
+		}
+	}
+}
+
+func TestWorkspaceRoots_NotInWorkspace(t *testing.T) {
+	// When not in a workspace directory, workspaceroots should return nil.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Use a temp dir that has no go.work.
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force GOWORK=off to ensure we're not in workspace mode.
+	t.Setenv("GOWORK", "off")
+
+	roots, err := workspaceroots()
+	if err != nil {
+		t.Fatalf("workspaceroots() error: %v", err)
+	}
+
+	if roots != nil {
+		t.Fatalf("expected nil roots outside workspace, got %v", roots)
+	}
+}
+
+func TestToplevel_Workspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	roots, err := toplevel(false)
+	if err != nil {
+		t.Fatalf("toplevel(false) error: %v", err)
+	}
+
+	if len(roots) != 3 {
+		t.Fatalf("expected 3 roots, got %d: %v", len(roots), roots)
+	}
+}
+
+func TestToplevel_WorkspaceDisabled(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest", "modA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	roots, err := toplevel(true)
+	if err != nil {
+		t.Fatalf("toplevel(true) error: %v", err)
+	}
+
+	// With workspace disabled, should return only the single module root.
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 root with workspace disabled, got %d: %v", len(roots), roots)
+	}
+
+	if !containsSuffix(roots[0], "modA") {
+		t.Errorf("root = %q; want suffix 'modA'", roots[0])
+	}
+}
+
+func TestChangedPackages_WorkspaceCrossModule(t *testing.T) {
+	// Test that changing a package in modB causes dependents in modA and
+	// transitively modC to be detected.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the differ: modB/pkg/b.go changed.
+	bPkgDir := filepath.Join(wsDir, "modB", "pkg")
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			bPkgDir: {Exists: true, Files: []string{"b.go"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// Expect: workspace.test/modB/pkg changed, and its dependents
+	// workspace.test/modA/pkg and workspace.test/modC/pkg should also be
+	// marked.
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+	sort.Strings(gotPaths)
+
+	wantPaths := []string{
+		"workspace.test/modA/pkg",
+		"workspace.test/modB/pkg",
+		"workspace.test/modC/pkg",
+	}
+
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s", diff)
+	}
+
+	// Verify the direct change.
+	var changePaths []string
+	for _, pkg := range pkgs.Changes {
+		changePaths = append(changePaths, pkg.ImportPath)
+	}
+	if len(changePaths) != 1 || changePaths[0] != "workspace.test/modB/pkg" {
+		t.Errorf("Changes = %v; want [workspace.test/modB/pkg]", changePaths)
+	}
+}
+
+func TestChangedPackages_WorkspaceIsolatedModule(t *testing.T) {
+	// Test that changing a package in a module with no dependents only
+	// reports that one package.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// modC/pkg has no dependents within the workspace.
+	cPkgDir := filepath.Join(wsDir, "modC", "pkg")
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			cPkgDir: {Exists: true, Files: []string{"c.go"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+
+	wantPaths := []string{"workspace.test/modC/pkg"}
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s", diff)
+	}
+}
+
+func TestChangedPackages_GoWorkFileChanged(t *testing.T) {
+	// When go.work itself is changed, all packages should be marked.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// go.work changed.
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			wsDir: {Exists: true, Files: []string{"go.work"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPrefixes("workspace.test/"))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// When go.work changes, all workspace packages should be in AllChanges.
+	if len(pkgs.AllChanges) < 3 {
+		var paths []string
+		for _, p := range pkgs.AllChanges {
+			paths = append(paths, p.ImportPath)
+		}
+		t.Errorf("expected at least 3 changed packages when go.work changes, got %d: %v", len(pkgs.AllChanges), paths)
+	}
+}
+
+func TestSetDisableWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest", "modA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake differ showing a change in modA/pkg.
+	aPkgDir := filepath.Join(wsDir, "pkg")
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			aPkgDir: {Exists: true, Files: []string{"a.go"}},
+		},
+	}
+
+	// With workspace disabled, only modA packages should be loaded.
+	gta, err := New(SetDiffer(difr), SetDisableWorkspace(true))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// With workspace disabled, the packager only loads modA's packages.
+	// modC (which depends on modA) should NOT appear because it's in a
+	// different module.
+	for _, pkg := range pkgs.AllChanges {
+		if pkg.ImportPath == "workspace.test/modC/pkg" {
+			t.Error("modC/pkg should not appear when workspace is disabled")
+		}
+	}
+}
+
+func containsSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -9,6 +9,185 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// TestChangedPackages_SymlinkedRoot verifies that gta correctly resolves
+// changed packages when the differ supplies a directory path that passes
+// through a symlink, while packages.Load reports Module.Dir in resolved
+// (canonical) form. This exercises canonicalDir in resolveLocal and the
+// root-normalization in New().
+func TestChangedPackages_SymlinkedRoot(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Resolve the real (canonical) path to the workspace fixture.
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	realWsDir, err := filepath.EvalSymlinks(wsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink pointing at the workspace fixture directory.
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realWsDir, linkDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Change into the workspace via the symlinked path so that the module
+	// root reported by `go list`/`go env` is the symlinked path.
+	if err := os.Chdir(linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// The differ reports the changed directory through the symlink path
+	// (as if the caller reached the repo via that symlink).
+	bPkgDirViaLink := filepath.Join(linkDir, "modB", "pkg")
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			bPkgDirViaLink: {Exists: true, Files: []string{"b.go"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+	sort.Strings(gotPaths)
+
+	// Expect the same result as TestChangedPackages_WorkspaceCrossModule:
+	// modB/pkg changed, and its dependents modA/pkg and modC/pkg should also
+	// be detected. An empty result here means symlink paths failed to match.
+	wantPaths := []string{
+		"workspace.test/modA/pkg",
+		"workspace.test/modB/pkg",
+		"workspace.test/modC/pkg",
+	}
+
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s\n(empty result indicates symlink path normalization is broken)", diff)
+	}
+}
+
+// TestChangedPackages_SymlinkedTestdataRoot guards EXTRA-2: the
+// `abs = canonicalDir(abs)` line in markedPackages() that canonicalizes the
+// differ-supplied path BEFORE the isIgnoredByGo check.
+//
+// Without EXTRA-2, a differ path whose un-resolved form contains a "testdata"
+// ancestor segment is silently dropped by isIgnoredByGo — even when its
+// canonical (EvalSymlinks) form lives under a registered module root.
+//
+// Mechanism reproduced here:
+//  1. The GTA roots are canonical: realWsDir = EvalSymlinks(testdata/workspacetest).
+//  2. A symlink `link` in a tempdir points at the gta module root (parent of
+//     testdata/), so `link/testdata/workspacetest/modB/pkg` is a valid path
+//     whose un-resolved form contains the "testdata" segment.
+//  3. The differ supplies `link/testdata/workspacetest/modB/pkg` as the changed
+//     directory.
+//  4. Without EXTRA-2: isIgnoredByGo walks up link/.../workspacetest (not in
+//     roots), reaches "testdata" → returns true → package silently dropped.
+//  5. With EXTRA-2: abs is canonicalized first → the roots match fires before
+//     "testdata" is reached → package is detected normally.
+func TestChangedPackages_SymlinkedTestdataRoot(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Resolve the canonical path to the workspace fixture dir (the GTA root).
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	realWsDir, err := filepath.EvalSymlinks(wsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve the canonical path to the gta module root (parent of testdata/).
+	gtaRoot, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	realGtaRoot, err := filepath.EvalSymlinks(gtaRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink in a tempdir pointing at the gta module root so that
+	// link/testdata/workspacetest/modB/pkg is a valid path containing the
+	// literal "testdata" segment but resolves canonically to the real modB/pkg.
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realGtaRoot, linkDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Change into the workspace via the REAL (canonical) path so that
+	// toplevel() returns the canonical root.  This ensures g.roots is
+	// canonical — the precondition that makes isIgnoredByGo's testdata trap
+	// fire when the un-canonicalized differ path is used.
+	if err := os.Chdir(realWsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// The differ supplies the changed directory through the symlinked path.
+	// Its un-resolved form is:  link/testdata/workspacetest/modB/pkg
+	// Its EvalSymlinks form is: <realGtaRoot>/testdata/workspacetest/modB/pkg
+	bPkgDirViaLink := filepath.Join(linkDir, "testdata", "workspacetest", "modB", "pkg")
+
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			bPkgDirViaLink: {Exists: true, Files: []string{"b.go"}},
+		},
+	}
+
+	// Use the canonical workspace root as the explicit root so that the roots
+	// are always in resolved form regardless of the CWD.
+	g, err := New(SetDiffer(difr), SetRoots(realWsDir))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := g.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+	sort.Strings(gotPaths)
+
+	// Expect the same result as TestChangedPackages_WorkspaceCrossModule.
+	// An empty result indicates that EXTRA-2 (abs = canonicalDir(abs)) is
+	// missing and the package was silently dropped by the testdata guard.
+	wantPaths := []string{
+		"workspace.test/modA/pkg",
+		"workspace.test/modB/pkg",
+		"workspace.test/modC/pkg",
+	}
+
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s\n(empty result means the symlinked differ path containing 'testdata' was silently dropped — EXTRA-2 is broken)", diff)
+	}
+}
+
 func TestChangedPackages_WorkspaceCrossModule(t *testing.T) {
 	// Test that changing a package in modB causes dependents in modA and
 	// transitively modC to be detected.

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -1,0 +1,166 @@
+package gta
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestChangedPackages_WorkspaceCrossModule(t *testing.T) {
+	// Test that changing a package in modB causes dependents in modA and
+	// transitively modC to be detected.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the differ: modB/pkg/b.go changed.
+	bPkgDir := filepath.Join(wsDir, "modB", "pkg")
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			bPkgDir: {Exists: true, Files: []string{"b.go"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// Expect: workspace.test/modB/pkg changed, and its dependents
+	// workspace.test/modA/pkg and workspace.test/modC/pkg should also be
+	// marked.
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+	sort.Strings(gotPaths)
+
+	wantPaths := []string{
+		"workspace.test/modA/pkg",
+		"workspace.test/modB/pkg",
+		"workspace.test/modC/pkg",
+	}
+
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s", diff)
+	}
+
+	// Verify the direct change.
+	var changePaths []string
+	for _, pkg := range pkgs.Changes {
+		changePaths = append(changePaths, pkg.ImportPath)
+	}
+	if len(changePaths) != 1 || changePaths[0] != "workspace.test/modB/pkg" {
+		t.Errorf("Changes = %v; want [workspace.test/modB/pkg]", changePaths)
+	}
+}
+
+func TestChangedPackages_WorkspaceIsolatedModule(t *testing.T) {
+	// Test that changing a package in a module with no dependents only
+	// reports that one package.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// modC/pkg has no dependents within the workspace.
+	cPkgDir := filepath.Join(wsDir, "modC", "pkg")
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			cPkgDir: {Exists: true, Files: []string{"c.go"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	var gotPaths []string
+	for _, pkg := range pkgs.AllChanges {
+		gotPaths = append(gotPaths, pkg.ImportPath)
+	}
+
+	wantPaths := []string{"workspace.test/modC/pkg"}
+	if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+		t.Errorf("AllChanges import paths (-want +got):\n%s", diff)
+	}
+}
+
+func TestChangedPackages_GoWorkFileChanged(t *testing.T) {
+	// When go.work itself is changed, all packages should be marked.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	wsDir, err := filepath.Abs(filepath.Join("testdata", "workspacetest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// go.work changed.
+	difr := &testDiffer{
+		diff: map[string]Directory{
+			wsDir: {Exists: true, Files: []string{"go.work"}},
+		},
+	}
+
+	gta, err := New(SetDiffer(difr), SetPrefixes("workspace.test/"))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	pkgs, err := gta.ChangedPackages()
+	if err != nil {
+		t.Fatalf("ChangedPackages() error: %v", err)
+	}
+
+	// When go.work changes, all workspace packages should be in AllChanges.
+	if len(pkgs.AllChanges) < 3 {
+		var paths []string
+		for _, p := range pkgs.AllChanges {
+			paths = append(paths, p.ImportPath)
+		}
+		t.Errorf("expected at least 3 changed packages when go.work changes, got %d: %v", len(pkgs.AllChanges), paths)
+	}
+}


### PR DESCRIPTION
## Summary
  
  Detect `go.mod`/`go.sum` changes precisely and mark only the dependent packages
  that actually changed, rather than falling back to marking every package when
  no `vendor/` tree is present.

  Rebased onto current `master`, which includes the single-root `go.work` support
  from #73. The fork's multi-root `go.work` commit is dropped — #73 supersedes it,
  and the cross-module tests added here confirm workspace detection works on the
  single-root base without multi-root code. The companion go.work PR is closed.

  ## Changes

  **Graph construction under module/workspace loads:**
  - `isLocalPackage` / `LocalImportersOf` on the package context.
  - Skip packages with load errors during dependency-graph construction.
  - Tolerate `PackageFromImport` errors for unresolvable dependents.
  - Filter non-local dependents out of reverse-graph traversal.

  **Precise go.mod/go.sum diffing:**
  - `gomod.go`: diff `go.mod` require directives and `go.sum` entries.
  - `BaseFileReader` interface plus `SetBaseGoMod` / `SetBaseGoSum`, sourcing old
    module-file content from the git differ or from explicitly supplied files.
  - `markedPackages()` diffs changed `go.mod`/`go.sum`, resolves the affected
    module paths to their local importers, and marks those. The mark-all path
    remains as fallback when no base is available; `go.work` changes still force
    full re-evaluation.

  **Path resolution:**
  - `BaseFileReader.ReadBaseFile` takes an absolute path; the git differ resolves
    it against the repository toplevel from `diff()` and rejects paths outside the
    repo. Removes the `roots`-based computation, which was correct only when the
    module root coincided with the git toplevel.
  - Regression test pinning the contract.

  **Tests:**
  - Cross-module workspace integration: a change in one module marks dependents in
    sibling modules; an isolated module reports only itself; a `go.work` change
    marks all workspace packages.

  ## Notes

  - Workspace opt-out is `GOWORK=off`; there is no gta flag.
  - `BaseFileReader` is new in this PR, so its absolute-path signature is not a
    breaking change.

  ## Testing

  `go test -count=1 -race ./...` and `go vet ./...` pass.